### PR TITLE
UX improvements to the file close confirm dialog

### DIFF
--- a/modules/web/css/fileDialog.css
+++ b/modules/web/css/fileDialog.css
@@ -40,6 +40,14 @@
     margin-right: 43px;
 }
 
+.close-file-confirm-dialog-btn{
+    float: left;
+}
+
+.close-file-confirm-dialog{
+    width: 500px;
+}
+
 .errors-container{
     margin: 50px 20px 20px 20px;
 }

--- a/modules/web/js/dialog/close-confirm-dialog.js
+++ b/modules/web/js/dialog/close-confirm-dialog.js
@@ -32,12 +32,16 @@ define(['jquery', './modal-dialog'], function ($, ModalDialog) {
             return;
         }
 
-        var dontSaveBtn = $("<button type='button' class='btn btn-primary btn-file-dialog'>Don't Save</button>");
-        this._saveBtn = this.getSubmitBtn();
+        var saveBtn = $("<button type='button' class='btn btn-primary btn-file-dialog'>Save</button>");
+        var dontSaveBtn = $("<button type='button' class='btn btn-primary btn-file-dialog" +
+                            " close-file-confirm-dialog-btn'>Don't Save</button>");
+        var cancelBtn = $("<button type='button' class='btn btn-default btn-file-dialog'" +
+                          " data-dismiss='modal'>Cancel</button>");
+        this._saveBtn = saveBtn;
         this._dontSaveBtn = dontSaveBtn;
-        this._saveBtn.after(dontSaveBtn);
-        this.setSubmitBtnText("Save");
-        this.setCloseBtnText("Cancel");
+
+        this.getFooter().empty();
+        this.getFooter().append(dontSaveBtn, cancelBtn, saveBtn);
 
         this._initialized = true;
     }
@@ -47,7 +51,11 @@ define(['jquery', './modal-dialog'], function ($, ModalDialog) {
         this.init();
 
         var name = options.file.getName();
-        this.setTitle(name + ' contains changes. Do you want to save them before closing?')
+        this.setTitle("'" + name + "' contains changes. Do you want to save them before closing?");
+
+        var body = this.getBody();
+        body.empty();
+        body.append($('<p><br>Your changes will be lost if you close this file without saving.</p>'))
 
         this._saveBtn.unbind('click');
         this._dontSaveBtn.unbind('click');


### PR DESCRIPTION
Earlier: 
![screenshot from 2017-02-10 16-54-37](https://cloud.githubusercontent.com/assets/3872221/22825228/fdc26104-efb1-11e6-9736-837a80b92d5b.png)

New:
![screenshot from 2017-02-10 16-54-06](https://cloud.githubusercontent.com/assets/3872221/22825235/02c4d844-efb2-11e6-900c-b41c0a1c7fce.png)

