### PR TITLE
Removing imports from imports view removes the imported packages tool palette view

### DIFF
--- a/modules/web/js/ballerina/item-provider/tool-palette-item-provider.js
+++ b/modules/web/js/ballerina/item-provider/tool-palette-item-provider.js
@@ -35,8 +35,13 @@ define(['log', 'lodash', './../env/package', './../tool-palette/tool-palette', '
             this._toolGroups = _.get(args, 'toolGroups', []);
             // array which contains tool groups that are added on the fly
             this._dynamicToolGroups = _.get(args, 'dynamicToolGroups', []);
+
             // Packages to be added to the tool palette by default in order.
             this._defaultImportedPackages = ["ballerina.net.http", "ballerina.lang.*"];
+
+            // views added to tool palette for each imported package keyed by package name
+            this._importedPackagesViews = {};
+
             this.init();
         };
 
@@ -109,7 +114,19 @@ define(['log', 'lodash', './../env/package', './../tool-palette/tool-palette', '
         ToolPaletteItemProvider.prototype.addImportToolGroup = function (package) {
             if (package instanceof Package) {
                 var group = this.getToolGroup(package);
-                this._toolPalette.addVerticallyFormattedToolGroup({group: group});
+                var groupView = this._toolPalette.addVerticallyFormattedToolGroup({group: group});
+                this._importedPackagesViews[package.getName()] = groupView;
+            }
+        };
+
+        /**
+         * Removes a tool group view from the tool palette for a given package name
+         * @param packageName - name of the package to be removed
+         */
+        ToolPaletteItemProvider.prototype.removeImportToolGroup = function (packageName) {
+            var removingView = this._importedPackagesViews[packageName];
+            if(!_.isNil(removingView)){
+                removingView.remove();
             }
         };
 

--- a/modules/web/js/ballerina/tool-palette/tool-palette.js
+++ b/modules/web/js/ballerina/tool-palette/tool-palette.js
@@ -183,6 +183,7 @@ define(['require', 'log', 'jquery', 'backbone', './tool-group-view', './tool-gro
             var groupView = new ToolGroupView(toolGroupOptions);
             var group = groupView.render(this.$el.find('.tool-import-wrapper'), _.isEqual('vertical', args.group.get('toolOrder')));
             this.$el.addClass('non-user-selectable');
+            return groupView;
         },
 
         /**

--- a/modules/web/js/ballerina/views/ballerina-file-editor.js
+++ b/modules/web/js/ballerina/views/ballerina-file-editor.js
@@ -339,14 +339,14 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
                 importDeclarations = this._model.getImportDeclarations();
             }
 
+            // render tool palette
+            this.toolPalette.render();
+
             // add current imported packages to tool pallet
             _.forEach(importDeclarations, function (importDeclaration) {
                 var package = BallerinaEnvironment.searchPackage(importDeclaration.getPackageName());
-                self.toolPalette.getItemProvider().addImport(package[0]);
+                self.toolPalette.getItemProvider().addImportToolGroup(package[0]);
             });
-
-            // render tool palette
-            this.toolPalette.render();
 
             // container for per-tab source view TODO improve source view to wrap this logic
             var sourceViewContainer = $(this._container).find(_.get(this._viewOptions, 'source_view.container'));
@@ -750,6 +750,7 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
                             log.debug("Delete import clicked :" + event.data.packageName);
                             $(event.data.wrapper).remove();
                             event.data.model.deleteImport(event.data.packageName);
+                            self.toolPalette.getItemProvider().removeImportToolGroup(event.data.packageName);
                         });
                     });
                 }


### PR DESCRIPTION
Keeps a reference to added package view in tool palette item provider and calls `remove` on it when removed.