### PR TITLE
Show vertical tool groups in collapsed state by default

### DIFF
--- a/modules/web/js/ballerina/tool-palette/tool-group-view.js
+++ b/modules/web/js/ballerina/tool-palette/tool-group-view.js
@@ -51,6 +51,12 @@ define(['require', 'log', 'jquery', 'd3', 'backbone', './tool-view'], function (
             groupBodyDiv.attr('class', "tool-group-body");
             this._$toolGroupBody = groupBodyDiv;
 
+            if(toolOrderVertical) {
+                // show vertical tool groups in collapsed state by default
+                groupBodyDiv.hide();
+                groupHeaderDiv.addClass('tool-group-header-collapse');
+            }
+
             // Iterate and stop adding duplicates of each function
             var tools = [];
             var toolDocumentMap = {};


### PR DESCRIPTION
Fixes #646 