### PR TITLE
Fixing incorrectly moving the center point of a statement container when its bounding box is moved

### DIFF
--- a/modules/web/js/ballerina/views/statement-container.js
+++ b/modules/web/js/ballerina/views/statement-container.js
@@ -308,6 +308,8 @@ define(['lodash', 'jquery', 'd3', 'log', 'd3utils', './point', './ballerina-view
         boundingBox.on('moved', function(offset){
             self._mainDropZone.attr('x', boundingBox.x());
             self._mainDropZone.attr('y', boundingBox.y());
+        }, this);
+        boundingBox.on('center-moved', function (offset) {
             self._topCenter.move(offset.dx, offset.dy);
         }, this);
         var dropZoneOptions = {


### PR DESCRIPTION
Center point of a statement container should be moved **only** if the center point of its bounding box is moved (`center-moved` event). This PR carries the changes for that.