### PR TITLE
rerenderCurrentPackageTool before redrawing in ballerina file editor.

### DIFF
--- a/modules/web/js/ballerina/views/ballerina-file-editor.js
+++ b/modules/web/js/ballerina/views/ballerina-file-editor.js
@@ -554,8 +554,8 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
                 self.setActiveView('design');
                 if(isSourceChanged || isSwaggerChanged || savedWhileInSourceView){
                     self._environment.resetCurrentPackage();
-                    self.reDraw();
                     self.rerenderCurrentPackageTool();
+                    self.reDraw();
                 }
             });
 


### PR DESCRIPTION
@roonyh @kaviththiranga Please check this.

This change was needed for rendering existing structs in typemapper.