### PR TITLE
Fixing action invocation arrows reposition issue

### DIFF
--- a/modules/web/js/ballerina/views/action-invocation-statement-view.js
+++ b/modules/web/js/ballerina/views/action-invocation-statement-view.js
@@ -87,6 +87,9 @@ define(['lodash', 'd3','log', './simple-statement-view', './../ast/action-invoca
             var model = this.getModel();
             // Calling super class's render function.
             (this.__proto__.__proto__).render.call(this, renderingContext);
+            // Disable the event registered at the super class for the top-edge-moved, since we override the event action
+            // TODO: we need to properly handle this at the super class level
+            this.stopListening(this.getBoundingBox(), 'top-edge-moved');
             var actionInvocationExpressionModel = this.getActionInvocationExpressionModel();
             var connectorModel = actionInvocationExpressionModel.getConnector();
             model.accept(this);
@@ -194,7 +197,9 @@ define(['lodash', 'd3','log', './simple-statement-view', './../ast/action-invoca
 
                 this.renderProcessorConnectEndPoint(renderingContext);
 
-                this.getBoundingBox().on('top-edge-moved', function (offset) {
+                this.listenTo(this.getBoundingBox(), 'top-edge-moved', function (offset) {
+                    this.getSvgRect().attr('y', parseFloat(this.getSvgRect().attr('y')) + offset);
+                    this.getSvgText().attr('y', parseFloat(this.getSvgText().attr('y')) + offset);
                     var currentY1ProcessorConnector = this._processorConnector.attr('y1');
                     var currentY1ProcessorConnector2 = this._processorConnector2.attr('y1');
                     var currentY2ProcessorConnector = this._processorConnector.attr('y2');
@@ -361,6 +366,9 @@ define(['lodash', 'd3','log', './simple-statement-view', './../ast/action-invoca
                 if ( (BallerinaASTFactory.isConnectorDeclaration(siblingConnectors[i]))
                          && (siblingConnectors[i]._connectorVariable == connectorName) ) {
                     self.getActionInvocationExpressionModel().setConnector(siblingConnectors[i]);
+                    // Stop listening to the top edge moved event. Since this is re initialized at the render arrows
+                    self.stopListening(self.getBoundingBox(), 'top-edge-moved');
+                    // TODO: refactor this
                     self.renderArrows(self.getDiagramRenderingContext());
                }
             });


### PR DESCRIPTION
This fixes the following:

Add a connector invocation and connect to a connector.
Edit the connector invocation expression
Now add a statement before the action invocation statement this won't properly move the arrows