### PR TITLE
fixing issue in path query parameter name issue

### DIFF
--- a/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/swagger/SwaggerConverterUtils.java
+++ b/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/swagger/SwaggerConverterUtils.java
@@ -240,8 +240,13 @@ public class SwaggerConverterUtils {
             if (entry.getHasQueryParams()) {
                 for (CodegenParameter codegenParameter : entry.queryParams) {
                     //TODO compare and merge if existing parameter edited.
+                    String variableName = (String) codegenParameter.
+                            vendorExtensions.get(SwaggerBallerinaConstants.VARIABLE_UUID_NAME);
+                    if((variableName == null ) || variableName.isEmpty()){
+                        variableName = codegenParameter.baseName;
+                    }
                     ParameterDef parameterDef = new ParameterDef(
-                            new NodeLocation("<unknown>", 0), codegenParameter.paramName,
+                            new NodeLocation("<unknown>", 0), variableName,
                             new SimpleTypeName(codegenParameter.dataType), new SymbolName("m"),
                             resourceBuilder.buildResource());
                     Annotation annotation = new Annotation(null, new SymbolName("http:QueryParam"),
@@ -253,8 +258,13 @@ public class SwaggerConverterUtils {
             if (entry.getHasPathParams()) {
                 for (CodegenParameter codegenParameter : entry.pathParams) {
                     //TODO compare and merge if existing parameter edited.
-                    ParameterDef parameterDef = new ParameterDef(
-                            new NodeLocation("<unknown>", 0), codegenParameter.paramName,
+                    String variableName = (String) codegenParameter.
+                            vendorExtensions.get(SwaggerBallerinaConstants.VARIABLE_UUID_NAME);
+                    if((variableName == null ) || variableName.isEmpty()){
+                        variableName = codegenParameter.baseName;
+                    }
+                        ParameterDef parameterDef = new ParameterDef(
+                            new NodeLocation("<unknown>", 0), variableName,
                             new SimpleTypeName(codegenParameter.dataType), new SymbolName("m"),
                             resourceBuilder.buildResource());
                     Annotation annotation = new Annotation(null, new SymbolName("http:PathParam"),

--- a/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/swagger/SwaggerResourceMapper.java
+++ b/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/swagger/SwaggerResourceMapper.java
@@ -155,14 +155,22 @@ public class SwaggerResourceMapper {
                         queryParameter.setIn("query");
                         queryParameter.setVendorExtension(SwaggerBallerinaConstants.VARIABLE_UUID_NAME,
                                 parameterDef.getName());
-                        queryParameter.setName(parameterDef.getName());
+                        String parameterName = parameterDef.getAnnotations().get(0).getValue();
+                        if((parameterName == null ) || parameterName.isEmpty()){
+                            parameterName = parameterDef.getName();
+                        }
+                        queryParameter.setName(parameterName);
                         queryParameter.required(true);
                         op.getOperation().addParameter(queryParameter);
                     }
                     if(parameterDef.getAnnotations().get(0).getName().equalsIgnoreCase("http:PathParam")){
                         PathParameter pathParameter = new PathParameter();
                         pathParameter.setType(typeName);
-                        pathParameter.setName(parameterDef.getName());
+                        String parameterName = parameterDef.getAnnotations().get(0).getValue();
+                        if((parameterName == null ) || parameterName.isEmpty()){
+                            parameterName = parameterDef.getName();
+                        }
+                        pathParameter.setName(parameterName);
                         pathParameter.setIn("path");
                         pathParameter.setVendorExtension(SwaggerBallerinaConstants.VARIABLE_UUID_NAME,
                                 parameterDef.getName());


### PR DESCRIPTION
This fix was not there in RC1. This issue is not a blocker as we can use same name for annotation and variable both. But its good if we can add this fix before GA.