### PR TITLE
Use ballerina$ and workspace$ in webpack aliases

### DIFF
--- a/modules/web/js/main.js
+++ b/modules/web/js/main.js
@@ -20,7 +20,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import Backbone from 'backbone';
 import MenuBar from './menu-bar/menu-bar';
-import BreadcrumbController from './breadcrumbs/breadcumbs';
+import BreadcrumbController from './breadcrumbs/breadcrumbs';
 import FileBrowser from './file-browser/file-browser';
 import TabController from './tab/file-tab-list';
 import CommandManager from './command/command';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,7 +84,8 @@ module.exports = {
             bal_utils: "ballerina/utils",
             bal_configs: "ballerina/configs",
             console: "launcher/console",
-            workspace: "workspace/module"
+            workspace$: "workspace/module",
+            ballerina$: "ballerina/module",
         }
     }
 


### PR DESCRIPTION
Adding ‘$’ behind alias names tells webpack to only match exact matches.
So requires like “ballerina/some/other/path” are not broken by this entry.

https://webpack.js.org/configuration/resolve/#resolve-alias

Also fixed a typo.