### PR TITLE
remove breakpoints on content modified

### DIFF
--- a/modules/web/js/tab/file-tab.js
+++ b/modules/web/js/tab/file-tab.js
@@ -110,7 +110,6 @@ define(['require', 'log', 'jquery', 'lodash', './tab', 'ballerina', 'workspace/f
             }, this);
 
             fileEditor.on('content-modified', function() {
-                console.log(arguments)
                 // TODO handle line number changes in a better way
                 // remove breakpoints if tree modified
                 if(!_.isEmpty(self.getBreakPoints())) {

--- a/modules/web/js/tab/file-tab.js
+++ b/modules/web/js/tab/file-tab.js
@@ -113,7 +113,7 @@ define(['require', 'log', 'jquery', 'lodash', './tab', 'ballerina', 'workspace/f
                 // TODO handle line number changes in a better way
                 // remove breakpoints if tree modified
                 if(!_.isEmpty(self.getBreakPoints())) {
-                    alerts.warn('Could not preserve debug points');
+                    alerts.warn('Could not preserve debug points', 60000);
                     self.removeAllBreakpoints();
                 }
             });

--- a/modules/web/js/tab/file-tab.js
+++ b/modules/web/js/tab/file-tab.js
@@ -109,6 +109,16 @@ define(['require', 'log', 'jquery', 'lodash', './tab', 'ballerina', 'workspace/f
                 DebugManager.removeBreakPoint(row, this._file.getName());
             }, this);
 
+            fileEditor.on('content-modified', function() {
+                console.log(arguments)
+                // TODO handle line number changes in a better way
+                // remove breakpoints if tree modified
+                if(!_.isEmpty(self.getBreakPoints())) {
+                    alerts.warn('Could not preserve debug points');
+                    self.removeAllBreakpoints();
+                }
+            });
+
             this.on('tab-removed', function() {
                 this.removeAllBreakpoints();
             });
@@ -187,6 +197,11 @@ define(['require', 'log', 'jquery', 'lodash', './tab', 'ballerina', 'workspace/f
 
         removeAllBreakpoints: function() {
             DebugManager.removeAllBreakpoints(this._file.getName());
+            this._fileEditor.trigger('reset-breakpoints', []);
+        },
+
+        getBreakPoints: function() {
+            return DebugManager.getDebugPoints(this._file.getName());
         }
 
     });


### PR DESCRIPTION
Currently debug points are not updated along with content editing. Debug points indicated are incorrect after content editing. So to avoid confusion we are removing breakpoints alerting user with a message. 
We have to work on a better solution for this limitation along with https://github.com/ballerinalang/composer/issues/1075