### PR TITLE
Using ace builds and adding syntax validating worker back

### DIFF
--- a/modules/web/js/ballerina/utils/ace-formatter.js
+++ b/modules/web/js/ballerina/utils/ace-formatter.js
@@ -17,8 +17,7 @@
  */
 define(function (require) {
 
-        var ace = require('brace');
-        var TokenIterator = ace.acequire("ace/token_iterator").TokenIterator;
+        var TokenIterator = ace.require("ace/token_iterator").TokenIterator;
 
         var BallerinaFormatter = {};
 

--- a/modules/web/js/ballerina/utils/ace-mirror-worker.js
+++ b/modules/web/js/ballerina/utils/ace-mirror-worker.js
@@ -1,0 +1,61 @@
+ace.define("ace/worker/mirror",["require","exports","module","ace/range","ace/document","ace/lib/lang"], function(require, exports, module) {
+"use strict";
+
+var Range = require("ace/range").Range;
+var Document = require("ace/document").Document;
+var lang = require("ace/lib/lang");
+
+var Mirror = exports.Mirror = function(sender) {
+    this.sender = sender;
+    var doc = this.doc = new Document("");
+
+    var deferredUpdate = this.deferredUpdate = lang.delayedCall(this.onUpdate.bind(this));
+
+    var _self = this;
+    sender.on("change", function(e) {
+        var data = e.data;
+        if (data[0].start) {
+            doc.applyDeltas(data);
+        } else {
+            for (var i = 0; i < data.length; i += 2) {
+                if (Array.isArray(data[i+1])) {
+                    var d = {action: "insert", start: data[i], lines: data[i+1]};
+                } else {
+                    var d = {action: "remove", start: data[i], end: data[i+1]};
+                }
+                doc.applyDelta(d, true);
+            }
+        }
+        if (_self.$timeout)
+            return deferredUpdate.schedule(_self.$timeout);
+        _self.onUpdate();
+    });
+};
+
+(function() {
+
+    this.$timeout = 500;
+
+    this.setTimeout = function(timeout) {
+        this.$timeout = timeout;
+    };
+
+    this.setValue = function(value) {
+        this.doc.setValue(value);
+        this.deferredUpdate.schedule(this.$timeout);
+    };
+
+    this.getValue = function(callbackId) {
+        this.sender.callback(this.doc.getValue(), callbackId);
+    };
+
+    this.onUpdate = function() {
+    };
+
+    this.isPending = function() {
+        return this.deferredUpdate.isPending();
+    };
+
+}).call(Mirror.prototype);
+
+});

--- a/modules/web/js/ballerina/utils/ace-mode.js
+++ b/modules/web/js/ballerina/utils/ace-mode.js
@@ -17,12 +17,14 @@
  */
 ace.define('ace/mode/ballerina',
     ["require", "exports", "module"], function (acequire, exports, module) {
-        require("brace/mode/javascript");
+        require("ace/mode-javascript");
+
+        acequire("ace/config").set("workerPath", "dist");
 
         var oop = acequire("ace/lib/oop");
         var JavaScriptMode = acequire("ace/mode/javascript").Mode;
         var TextHighlightRules = acequire("ace/mode/text_highlight_rules").TextHighlightRules;
-        var WorkerClient = acequire("ace/worker/worker_client").WorkerClient;
+        var WorkerClient = acequire("ace/worker/worker_client").UIWorkerClient;
 
         var BallerinaHighlightRules = function () {
 
@@ -61,7 +63,7 @@ ace.define('ace/mode/ballerina',
             this.HighlightRules = BallerinaHighlightRules;
 
             this.createWorker = function(session) {
-                var worker = new WorkerClient(["ace", "bal_utils", "bal_configs"], "bal_utils/ace-worker", "WorkerModule");
+                var worker = new WorkerClient(["ace/ace", "bal_utils", "bal_configs"], "ace/worker/ballerina", "WorkerModule");
                 worker.attachToDocument(session.getDocument());
 
                 worker.on("lint", function(results) {

--- a/modules/web/js/ballerina/utils/ace-worker.js
+++ b/modules/web/js/ballerina/utils/ace-worker.js
@@ -15,45 +15,47 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-define(function(require, exports, module) {
-    // TODO: FIX THIS WORKER TO USE BRACE AND UCOMMENT
+ace.define('ace/worker/ballerina', ['require', 'exports', 'module'], function(acequire, exports, module) {
+    var oop = acequire("ace/lib/oop");
+    var backends = require("bal_configs/backends");
 
-    // var oop = require("ace/lib/oop");
-    // var backends = require("bal_configs/backends");
-    // var Mirror = require("ace/worker/mirror").Mirror;
-    //
-    // var WorkerModule = exports.WorkerModule = function(sender) {
-    //     Mirror.call(this, sender);
-    // };
-    //
-    // // Mirror is a simple class which keeps main and webWorker versions of the document in sync
-    // oop.inherits(WorkerModule, Mirror);
-    //
-    // (function() {
-    //     this.onUpdate = function() {
-    //         var value = this.doc.getValue();
-    //         if(value.trim()){
-    //             var errors = [];
-    //             var content = { "content": value};
-    //             var request = new XMLHttpRequest();
-    //             var self = this;
-    //
-    //             request.onreadystatechange = function() {
-    //                 if(request.readyState === 4) {
-    //                     if(request.status === 200) {
-    //                         errors = (JSON.parse(request.responseText)).errors;
-    //                         self.sender.emit("lint", errors);
-    //                     }
-    //                 }
-    //             };
-    //
-    //             request.open('POST', backends.services.validator.endpoint, true);
-    //             request.setRequestHeader("Content-type", "application/json");
-    //             request.send(JSON.stringify(content));
-    //         } else {
-    //             this.sender.emit("lint", []);
-    //         }
-    //     };
-    // }).call(WorkerModule.prototype);
+    // This require defines ace/worker/mirror so we can ace.require ace/worker/mirror later
+    require('./ace-mirror-worker');
+
+    var Mirror = acequire("ace/worker/mirror").Mirror;
+
+    var WorkerModule = exports.WorkerModule = function(sender) {
+        Mirror.call(this, sender);
+    };
+
+    // Mirror is a simple class which keeps main and webWorker versions of the document in sync
+    oop.inherits(WorkerModule, Mirror);
+
+    (function() {
+        this.onUpdate = function() {
+            var value = this.doc.getValue();
+            if(value.trim()){
+                var errors = [];
+                var content = { "content": value};
+                var request = new XMLHttpRequest();
+                var self = this;
+
+                request.onreadystatechange = function() {
+                    if(request.readyState === 4) {
+                        if(request.status === 200) {
+                            errors = (JSON.parse(request.responseText)).errors;
+                            self.sender.emit("lint", errors);
+                        }
+                    }
+                };
+
+                request.open('POST', backends.services.validator.endpoint, true);
+                request.setRequestHeader("Content-type", "application/json");
+                request.send(JSON.stringify(content));
+            } else {
+                this.sender.emit("lint", []);
+            }
+        };
+    }).call(WorkerModule.prototype);
 
 });

--- a/modules/web/js/ballerina/views/ballerina-file-editor.js
+++ b/modules/web/js/ballerina/views/ballerina-file-editor.js
@@ -806,7 +806,7 @@ define(['lodash', 'jquery', 'log', './ballerina-view', './service-definition-vie
                     matches = [];
 
                     // regex used to determine if a string contains the substring `q`
-                    substrRegex = new RegExp(q, 'i');
+                    substringRegex = new RegExp(q, 'i');
 
                     // iterate through the pool of strings and for any string that
                     // contains the substring `q`, add it to the `matches` array

--- a/modules/web/js/ballerina/views/source-view.js
+++ b/modules/web/js/ballerina/views/source-view.js
@@ -18,17 +18,17 @@
 define(['log', 'lodash', 'jquery', 'event_channel', 'beautify'],
     function(log, _, $, EventChannel, Beautify) {
 
-    var ace = require('brace');
-    require('brace/ext/language_tools');
-    var language_tools = ace.acequire('ace/ext/language_tools');
-    var Range = ace.acequire('ace/range');
+    require('ace/ace');
+    require('ace/ext-language_tools');
+    var language_tools = ace.require('ace/ext/language_tools');
+    var Range = ace.require('ace/range');
 
     // require possible themes
-    require('brace/theme/twilight');
+    require('ace/theme-twilight');
 
     // require ballerina mode
     require('../utils/ace-mode');
-    var mode = ace.acequire('ace/mode/ballerina')
+    var mode = ace.require('ace/mode/ballerina')
 
     /**
      * @class SourceView
@@ -59,7 +59,7 @@ define(['log', 'lodash', 'jquery', 'event_channel', 'beautify'],
     SourceView.prototype.render = function () {
         var self = this;
         this._editor = ace.edit(this._container);
-        var mode = ace.acequire(_.get(this._options, 'mode')).Mode;
+        var mode = ace.require(_.get(this._options, 'mode')).Mode;
         this._editor.getSession().setMode(_.get(this._options, 'mode'));
         //Avoiding ace warning
         this._editor.$blockScrolling = Infinity;
@@ -68,7 +68,7 @@ define(['log', 'lodash', 'jquery', 'event_channel', 'beautify'],
         var editorFontSize = (this._storage.get("pref:sourceViewFontSize") != null) ? this._storage.get("pref:sourceViewFontSize")
             : _.get(this._options, 'font_size');
 
-        var editorTheme = ace.acequire(editorThemeName);
+        var editorTheme = ace.require(editorThemeName);
 
         this._editor.setTheme(editorTheme);
         this._editor.setFontSize(editorFontSize);
@@ -227,7 +227,7 @@ define(['log', 'lodash', 'jquery', 'event_channel', 'beautify'],
         if(this.debugPointMarker != undefined){
             this._editor.getSession().removeMarker(this.debugPointMarker);
         }
-    }    
+    }
 
     SourceView.prototype.isClean = function(){
        return this._editor.getSession().getUndoManager().isClean();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,12 @@ var path = require('path');
 var webpack = require("webpack");
 
 module.exports = {
-    entry: './modules/web/index.js',
+    entry: {
+      bundle: './modules/web/index.js',
+      'worker-ballerina': './modules/web/js/ballerina/utils/ace-worker.js'
+    },
     output: {
-        filename: 'bundle.js',
+        filename: '[name].js',
         path: path.resolve(__dirname, 'modules/web/dist')
     },
     module: {
@@ -46,6 +49,7 @@ module.exports = {
             select2: "select2-4.0.3/dist/js/select2.full.min",
             underscore: "lodash_v4.13.1/lodash",
             beautify: "beautify/beautify",
+            ace: "ace-builds/src-noconflict",
             ///////////////////////
             // custom modules ////
             //////////////////////

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,9 @@ module.exports = {
       ]
     },
     plugins: [
-        new webpack.optimize.UglifyJsPlugin()
+        new webpack.optimize.UglifyJsPlugin({
+          sourceMap: true
+        })
     ],
     node: { module: "empty", net: "empty", fs: "empty" },
     devtool: 'source-map',


### PR DESCRIPTION
Using ‘ace-builds’ official package instead of ‘brace’
Added the syntax validation worker back.

The mirror worker for ace-editor is not provided in ace-builds. So had to manually add it. Filed an issue regarding this: ajaxorg/ace-builds#100