### PR TITLE
Fix the issue on Firefox where service/function/connector names doesn't change

### DIFF
--- a/modules/web/js/ballerina/utils/dropdown.js
+++ b/modules/web/js/ballerina/utils/dropdown.js
@@ -121,7 +121,7 @@ define(['lodash', 'jquery'], function (_, $) {
         $(this.dropdownButton).keypress(function (e) {
             var enteredKey = e.which || e.charCode || e.keyCode;
             // Disabling enter key
-            if (enteredKey == 13) {
+            if (_.isEqual(enteredKey, 13)) {
                 $(this).click();
                 e.stopPropagation();
             }

--- a/modules/web/js/ballerina/views/connector-definition-view.js
+++ b/modules/web/js/ballerina/views/connector-definition-view.js
@@ -190,25 +190,29 @@ define(['lodash', 'log', 'd3', 'd3utils', 'jquery', 'alerts', './svg-canvas', '.
                 .on("change paste keyup", function () {
                     self.getModel().setConnectorName($(this).text());
                 }).on("click", function (event) {
-                event.stopPropagation();
-            }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
                     event.stopPropagation();
-                    return false;
-                }
+                }).keypress(function (e) {
+                    /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                     (Chrome and IE ignore keypress event of these keys in browser level)*/
+                    if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                        var enteredKey = e.which || e.charCode || e.keyCode;
+                        // Disabling enter key
+                        if (_.isEqual(enteredKey, 13)) {
+                            event.stopPropagation();
+                            return false;
+                        }
 
-                var newServiceName = $(this).text() + String.fromCharCode(enteredKey);
+                        var newServiceName = $(this).text() + String.fromCharCode(enteredKey);
 
-                try {
-                    self.getModel().setConnectorName(newServiceName);
-                } catch (error) {
-                    Alerts.error(error);
-                    event.stopPropagation();
-                    return false;
-                }
-            });
+                        try {
+                            self.getModel().setConnectorName(newServiceName);
+                        } catch (error) {
+                            Alerts.error(error);
+                            event.stopPropagation();
+                            return false;
+                        }
+                    }
+                });
 
             this.getModel().on('child-added', function (child) {
                 self.visit(child);

--- a/modules/web/js/ballerina/views/connector-definition-view.js
+++ b/modules/web/js/ballerina/views/connector-definition-view.js
@@ -198,7 +198,7 @@ define(['lodash', 'log', 'd3', 'd3utils', 'jquery', 'alerts', './svg-canvas', '.
                         var enteredKey = e.which || e.charCode || e.keyCode;
                         // Disabling enter key
                         if (_.isEqual(enteredKey, 13)) {
-                            event.stopPropagation();
+                            e.stopPropagation();
                             return false;
                         }
 
@@ -208,7 +208,7 @@ define(['lodash', 'log', 'd3', 'd3utils', 'jquery', 'alerts', './svg-canvas', '.
                             self.getModel().setConnectorName(newServiceName);
                         } catch (error) {
                             Alerts.error(error);
-                            event.stopPropagation();
+                            e.stopPropagation();
                             return false;
                         }
                     }

--- a/modules/web/js/ballerina/views/constant-definition-view.js
+++ b/modules/web/js/ballerina/views/constant-definition-view.js
@@ -58,18 +58,22 @@ define(['lodash', 'jquery', 'log', 'alerts', './ballerina-view', './../ast/node'
                 "contenteditable": true,
                 class: "constant-declaration-field"
             }).keypress(function (e) {
-                // Updating annotation text of the model on typing.
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                var newIdentifier = $(this).text() + String.fromCharCode(enteredKey);
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    // Updating annotation text of the model on typing.
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    var newIdentifier = $(this).text() + String.fromCharCode(enteredKey);
 
-                // Validation the identifier against grammar.
-                if (!ASTNode.isValidIdentifier(newIdentifier)) {
-                    var errorString = "Invalid identifier for a parameter: " + newIdentifier;
-                    Alerts.error(errorString);
-                    event.stopPropagation();
-                    return false;
-                } else {
-                    self.getModel().setIdentifier(newIdentifier);
+                    // Validation the identifier against grammar.
+                    if (!ASTNode.isValidIdentifier(newIdentifier)) {
+                        var errorString = "Invalid identifier for a parameter: " + newIdentifier;
+                        Alerts.error(errorString);
+                        e.stopPropagation();
+                        return false;
+                    } else {
+                        self.getModel().setIdentifier(newIdentifier);
+                    }
                 }
             }).keyup(function(){
                 try {
@@ -93,22 +97,26 @@ define(['lodash', 'jquery', 'log', 'alerts', './ballerina-view', './../ast/node'
                 "contenteditable": true,
                 class: "constant-declaration-field"
             }).keypress(function (e) {
-                // Updating annotation text of the model on typing.
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    // Updating annotation text of the model on typing.
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Disabling enter key
+                    if (_.isEqual(enteredKey, 13)) {
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newValue = $(this).text() + String.fromCharCode(enteredKey);
+                    var newValue = $(this).text() + String.fromCharCode(enteredKey);
 
-                try {
-                    self.getModel().setValue(newValue);
-                } catch (errorString) {
-                    Alerts.error(errorString);
-                    event.stopPropagation();
-                    return false;
+                    try {
+                        self.getModel().setValue(newValue);
+                    } catch (errorString) {
+                        Alerts.error(errorString);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             }).keyup(function () {
                 try {

--- a/modules/web/js/ballerina/views/constant-definitions-pane-view.js
+++ b/modules/web/js/ballerina/views/constant-definitions-pane-view.js
@@ -116,23 +116,27 @@ define(['require', 'lodash', 'jquery', 'log', 'd3utils', 'd3', 'alerts', './poin
 
             // Add new constant upon enter key.
             $(constantIdentifierText).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
-                    constantAddCompleteButtonPane.click();
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Disabling enter key
+                    if (_.isEqual(enteredKey, 13)) {
+                        constantAddCompleteButtonPane.click();
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
+                    var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
 
-                // Validation the identifier against grammar.
-                if (!ASTNode.isValidIdentifier(newIdentifier)) {
-                    var errorString = "Invalid identifier for a parameter: " + newIdentifier;
-                    log.error(errorString);
-                    Alerts.error(errorString);
-                    event.stopPropagation();
-                    return false;
+                    // Validation the identifier against grammar.
+                    if (!ASTNode.isValidIdentifier(newIdentifier)) {
+                        var errorString = "Invalid identifier for a parameter: " + newIdentifier;
+                        log.error(errorString);
+                        Alerts.error(errorString);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             });
 
@@ -140,9 +144,9 @@ define(['require', 'lodash', 'jquery', 'log', 'd3utils', 'd3', 'alerts', './poin
             $(constantValueText).keypress(function(e){
                 var enteredKey = e.which || e.charCode || e.keyCode;
                 // Disabling enter key
-                if (enteredKey == 13) {
+                if (_.isEqual(enteredKey, 13)) {
                     constantAddCompleteButtonPane.click();
-                    event.stopPropagation();
+                    e.stopPropagation();
                     return false;
                 }
             });

--- a/modules/web/js/ballerina/views/function-definition-view.js
+++ b/modules/web/js/ballerina/views/function-definition-view.js
@@ -289,25 +289,29 @@ define(['lodash', 'log', 'event_channel',  'alerts', './svg-canvas', './../ast/f
                     .on("change paste keyup", function () {
                         self.getModel().setFunctionName($(this).text());
                     }).on("click", function (event) {
-                    event.stopPropagation();
-                }).keypress(function (e) {
-                    var enteredKey = e.which || e.charCode || e.keyCode;
-                    // Disabling enter key
-                    if (enteredKey == 13) {
                         event.stopPropagation();
-                        return false;
-                    }
+                    }).keypress(function (e) {
+                        /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                         (Chrome and IE ignore keypress event of these keys in browser level)*/
+                        if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                            var enteredKey = e.which || e.charCode || e.keyCode;
+                            // Disabling enter key
+                            if (_.isEqual(enteredKey, 13)) {
+                                e.stopPropagation();
+                                return false;
+                            }
 
-                    var newServiceName = $(this).text() + String.fromCharCode(enteredKey);
+                            var newServiceName = $(this).text() + String.fromCharCode(enteredKey);
 
-                    try {
-                        self.getModel().setFunctionName(newServiceName);
-                    } catch (error) {
-                        Alerts.error(error);
-                        event.stopPropagation();
-                        return false;
-                    }
-                });
+                            try {
+                                self.getModel().setFunctionName(newServiceName);
+                            } catch (error) {
+                                Alerts.error(error);
+                                e.stopPropagation();
+                                return false;
+                            }
+                        }
+                    });
             } else {
                 // Making the main function title non editable.
                 $(this.getTitle()).removeAttr("contenteditable");

--- a/modules/web/js/ballerina/views/resource-parameter-view.js
+++ b/modules/web/js/ballerina/views/resource-parameter-view.js
@@ -206,21 +206,25 @@ define(['lodash', 'jquery', 'log', 'alerts', './ballerina-view', './../ast/argum
                 type: "text",
                 val: this.getModel().getIdentifier()
             }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Disabling enter key
+                    if (_.isEqual(enteredKey, 13)) {
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
+                    var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
 
-                try {
-                    self.getModel().setIdentifier(newIdentifier);
-                } catch (error) {
-                    Alerts.error(error);
-                    event.stopPropagation();
-                    return false;
+                    try {
+                        self.getModel().setIdentifier(newIdentifier);
+                    } catch (error) {
+                        Alerts.error(error);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             }).keyup(function(){
                 self.getModel().setIdentifier($(this).val());

--- a/modules/web/js/ballerina/views/resource-parameters-pane-view.js
+++ b/modules/web/js/ballerina/views/resource-parameters-pane-view.js
@@ -139,23 +139,27 @@ define(['lodash', 'log', 'jquery', 'alerts', './resource-parameter-view', './../
                 type: "text",
                 "placeholder": "m"
             }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
-                    addButton.click();
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Disabling enter key
+                    if (_.isEqual(enteredKey, 13)) {
+                        addButton.click();
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
+                    var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
 
-                // Validation the identifier against grammar.
-                if (!ASTNode.isValidIdentifier(newIdentifier)) {
-                    var errorString = "Invalid identifier for a parameter: " + newIdentifier;
-                    log.error(errorString);
-                    Alerts.error(errorString);
-                    event.stopPropagation();
-                    return false;
+                    // Validation the identifier against grammar.
+                    if (!ASTNode.isValidIdentifier(newIdentifier)) {
+                        var errorString = "Invalid identifier for a parameter: " + newIdentifier;
+                        log.error(errorString);
+                        Alerts.error(errorString);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             }).appendTo(parameterWrapper);
 

--- a/modules/web/js/ballerina/views/return-type-view.js
+++ b/modules/web/js/ballerina/views/return-type-view.js
@@ -128,7 +128,7 @@ define(['lodash', 'jquery', 'log', 'alerts', './ballerina-view'],
                         self.getModel().setIdentifier(newIdentifier);
                     } catch (error) {
                         Alerts.error(error);
-                        event.stopPropagation();
+                        e.stopPropagation();
                         return false;
                     }
                 }).keyup(function(){

--- a/modules/web/js/ballerina/views/return-types-pane-view.js
+++ b/modules/web/js/ballerina/views/return-types-pane-view.js
@@ -112,23 +112,27 @@ define(['lodash', 'log', 'jquery', 'alerts', './return-type-view', './../ast/nod
                 type: "text",
                 "placeholder": "m"
             }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
-                    addButton.click();
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Disabling enter key
+                    if (_.isEqual(enteredKey, 13)) {
+                        addButton.click();
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
+                    var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
 
-                // Validation the identifier against grammar.
-                if (!ASTNode.isValidIdentifier(newIdentifier)) {
-                    var errorString = "Invalid identifier for a return type: " + newIdentifier;
-                    log.error(errorString);
-                    Alerts.error(errorString);
-                    event.stopPropagation();
-                    return false;
+                    // Validation the identifier against grammar.
+                    if (!ASTNode.isValidIdentifier(newIdentifier)) {
+                        var errorString = "Invalid identifier for a return type: " + newIdentifier;
+                        log.error(errorString);
+                        Alerts.error(errorString);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             }).toggle(self._model.hasNamedReturnTypes()).appendTo(returnTypeWrapper);
 

--- a/modules/web/js/ballerina/views/service-definition-view.js
+++ b/modules/web/js/ballerina/views/service-definition-view.js
@@ -165,21 +165,25 @@ define(['lodash', 'log', 'd3', 'd3utils', 'jquery', 'alerts', './svg-canvas', '.
                 }).on("click", function (event) {
                     event.stopPropagation();
                 }).keypress(function (e) {
-                    var enteredKey = e.which || e.charCode || e.keyCode;
-                    // Disabling enter key
-                    if (enteredKey == 13) {
-                        event.stopPropagation();
-                        return false;
-                    }
+                    /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                     (Chrome and IE ignore keypress event of these keys in browser level)*/
+                    if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                        var enteredKey = e.which || e.charCode || e.keyCode;
+                        // Disabling enter key
+                        if (_.isEqual(enteredKey, 13)) {
+                            e.stopPropagation();
+                            return false;
+                        }
 
-                    var newServiceName = $(this).text() + String.fromCharCode(enteredKey);
+                        var newServiceName = $(this).text() + String.fromCharCode(enteredKey);
 
-                    try {
-                        self.getModel().setServiceName(newServiceName);
-                    } catch (error) {
-                        Alerts.error(error);
-                        event.stopPropagation();
-                        return false;
+                        try {
+                            self.getModel().setServiceName(newServiceName);
+                        } catch (error) {
+                            Alerts.error(error);
+                            e.stopPropagation();
+                            return false;
+                        }
                     }
                 });
 

--- a/modules/web/js/ballerina/views/struct-definition-view.js
+++ b/modules/web/js/ballerina/views/struct-definition-view.js
@@ -66,21 +66,25 @@ define(['lodash', 'log', 'd3', 'alerts', './ballerina-view', 'ballerina/ast/ball
                 }).on("click", function (event) {
                     event.stopPropagation();
                 }).keypress(function (e) {
-                    var enteredKey = e.which || e.charCode || e.keyCode;
-                    // Disabling enter key
-                    if (enteredKey == 13) {
-                        event.stopPropagation();
-                        return false;
-                    }
+                    /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                     (Chrome and IE ignore keypress event of these keys in browser level)*/
+                    if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                        var enteredKey = e.which || e.charCode || e.keyCode;
+                        // Disabling enter key
+                        if (_.isEqual(enteredKey, 13)) {
+                            e.stopPropagation();
+                            return false;
+                        }
 
-                    var newServiceName = $(this).val() + String.fromCharCode(enteredKey);
+                        var newServiceName = $(this).val() + String.fromCharCode(enteredKey);
 
-                    try {
-                        self.getModel().setStructName(newServiceName);
-                    } catch (error) {
-                        Alerts.error(error);
-                        event.stopPropagation();
-                        return false;
+                        try {
+                            self.getModel().setStructName(newServiceName);
+                        } catch (error) {
+                            Alerts.error(error);
+                            e.stopPropagation();
+                            return false;
+                        }
                     }
                 });
 
@@ -138,22 +142,26 @@ define(['lodash', 'log', 'd3', 'alerts', './ballerina-view', 'ballerina/ast/ball
                 class: "struct-identifier-text-input",
                 "placeholder": "Identifier"
             }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Adding new variable upon enter key.
-                if (enteredKey == 13) {
-                    addStructVariableButton.click();
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Adding new variable upon enter key.
+                    if (_.isEqual(enteredKey, 13)) {
+                        addStructVariableButton.click();
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
+                    var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
 
-                // Validation the identifier against grammar.
-                if (!ASTNode.isValidIdentifier(newIdentifier)) {
-                    var errorString = "Invalid identifier for a variable: " + newIdentifier;
-                    Alerts.error(errorString);
-                    event.stopPropagation();
-                    return false;
+                    // Validation the identifier against grammar.
+                    if (!ASTNode.isValidIdentifier(newIdentifier)) {
+                        var errorString = "Invalid identifier for a variable: " + newIdentifier;
+                        Alerts.error(errorString);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             }).keydown(function(e){
                 var enteredKey = e.which || e.charCode || e.keyCode;

--- a/modules/web/js/ballerina/views/struct-variable-definition-view.js
+++ b/modules/web/js/ballerina/views/struct-variable-definition-view.js
@@ -146,21 +146,25 @@ define(['lodash', 'jquery', 'log', 'alerts', './ballerina-view'],
                 class: "struct-variable-identifier-text-input",
                 val: this.getModel().getName()
             }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
-                    event.stopPropagation();
-                    return false;
-                }
+                /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                 (Chrome and IE ignore keypress event of these keys in browser level)*/
+                if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                    var enteredKey = e.which || e.charCode || e.keyCode;
+                    // Disabling enter key
+                    if (_.isEqual(enteredKey, 13)) {
+                        e.stopPropagation();
+                        return false;
+                    }
 
-                var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
+                    var newIdentifier = $(this).val() + String.fromCharCode(enteredKey);
 
-                try {
-                    self.getModel().setName(newIdentifier);
-                } catch (error) {
-                    Alerts.error(error);
-                    event.stopPropagation();
-                    return false;
+                    try {
+                        self.getModel().setName(newIdentifier);
+                    } catch (error) {
+                        Alerts.error(error);
+                        e.stopPropagation();
+                        return false;
+                    }
                 }
             }).keydown(function(e){
                 var enteredKey = e.which || e.charCode || e.keyCode;

--- a/modules/web/js/ballerina/views/type-mapper-definition-view.js
+++ b/modules/web/js/ballerina/views/type-mapper-definition-view.js
@@ -104,22 +104,26 @@ define(['lodash', 'log', './ballerina-view', './variables-view', './type-struct-
                 .on("change paste keyup", function () {
                     self.getModel().setTypeMapperName($(this).text());
                 }).on("click", function (event) {
-                event.stopPropagation();
-            }).keypress(function (e) {
-                var enteredKey = e.which || e.charCode || e.keyCode;
-                // Disabling enter key
-                if (enteredKey == 13) {
                     event.stopPropagation();
-                    return false;
-                }
-                var newTypeMapperName = $(this).val() + String.fromCharCode(enteredKey);
-                try {
-                    self.getModel().setTypeMapperName(newTypeMapperName);
-                } catch (error) {
-                    event.stopPropagation();
-                    return false;
-                }
-            });
+                }).keypress(function (e) {
+                    /* Ignore Delete and Backspace keypress in firefox and capture other keypress events.
+                     (Chrome and IE ignore keypress event of these keys in browser level)*/
+                    if (!_.isEqual(e.key, "Delete") && !_.isEqual(e.key, "Backspace")) {
+                        var enteredKey = e.which || e.charCode || e.keyCode;
+                        // Disabling enter key
+                        if (_.isEqual(enteredKey, 13)) {
+                            e.stopPropagation();
+                            return false;
+                        }
+                        var newTypeMapperName = $(this).val() + String.fromCharCode(enteredKey);
+                        try {
+                            self.getModel().setTypeMapperName(newTypeMapperName);
+                        } catch (error) {
+                            e.stopPropagation();
+                            return false;
+                        }
+                    }
+                });
 
             var dataMapperContainerId = "data-mapper-container___" + this._model.id;
             var sourceId = 'sourceStructs' + this.getModel().id;

--- a/modules/web/js/ballerina/views/variable-definitions-pane-view.js
+++ b/modules/web/js/ballerina/views/variable-definitions-pane-view.js
@@ -136,7 +136,7 @@ define(['require', 'lodash', 'log', 'jquery', 'alerts', './variable-definition-v
                     var errorString = "Invalid identifier for a variable: " + newIdentifier;
                     log.error(errorString);
                     Alerts.error(errorString);
-                    event.stopPropagation();
+                    e.stopPropagation();
                     return false;
                 }
             });


### PR DESCRIPTION
This fix will listen to the keypress() event and then check whether pressed keys are Delete or Backspace. If it is not then proceed as before and if it is ignore these keys and let them do there default behaviors. This is only checked in Firefox as chrome and IE don't fire keypress() for Backspace or Delete.

Fix the issue: https://github.com/ballerinalang/composer/issues/1071

Note: Did not use the character code as Delete and "." has the same charcode