### PR TITLE
Fork/Join statement initial implementation (After resolving conflicts)

### DIFF
--- a/modules/web/js/ballerina/ast/ballerina-ast-factory.js
+++ b/modules/web/js/ballerina/ast/ballerina-ast-factory.js
@@ -33,7 +33,8 @@ define(['lodash', './ballerina-ast-root', './service-definition', './function-de
         './expressions/binary-expression', './expressions/unary-expression','./connector-action', './struct-definition', './constant-definition',
         './statements/variable-definition-statement', './worker-invoke', './expressions/reference-type-init-expression',
         './expressions/array-init-expression', './worker-receive','./struct-type','./expressions/struct-field-access-expression',
-        './statements/block-statement','./expressions/type-cast-expression','./variable-definition', './statements/break-statement', './statements/throw-statement', './statements/comment-statement'],
+        './statements/block-statement','./expressions/type-cast-expression','./variable-definition', './statements/break-statement', './statements/throw-statement', './statements/comment-statement',
+        './statements/fork-statement', './statements/join-statement', './statements/timeout-statement', './statements/forkjoin-statement'],
     function (_, ballerinaAstRoot, serviceDefinition, functionDefinition, connectorDefinition, resourceDefinition,
               workerDeclaration, statement, conditionalStatement, connectorDeclaration, expression, ifElseStatement,
               ifStatement, elseStatement, elseIfStatement, tryCatchStatement, tryStatement, catchStatement, replyStatement,
@@ -46,7 +47,7 @@ define(['lodash', './ballerina-ast-root', './service-definition', './function-de
               unaryExpression, connectorAction, structDefinition, constantDefinition, variableDefinitionStatement,
               workerInvoke, referenceTypeInitExpression, arrayInitExpression, workerReceive,structType,
               structFieldAccessExpression,blockStatement,typeCastExpression,variableDefinition, breakStatement,
-              throwStatement, commentStatement) {
+              throwStatement, commentStatement, forkStatement, joinStatement, timeoutStatement, forkJoinStatement) {
 
 
 
@@ -625,6 +626,38 @@ define(['lodash', './ballerina-ast-root', './service-definition', './function-de
          */
         BallerinaASTFactory.createCommentStatement = function (args) {
           return new commentStatement(args);
+        };
+
+        /**
+        * creates forkStatement
+        * @param args
+        */
+        BallerinaASTFactory.createForkStatement = function (args) {
+          return new forkStatement(args);
+        };
+
+        /**
+        * creates joinStatement
+        * @param args
+        */
+        BallerinaASTFactory.createJoinStatement = function (args) {
+         return new joinStatement(args);
+        };
+
+        /**
+        * creates timeoutStatement
+        * @param args
+        */
+        BallerinaASTFactory.createTimeoutStatement = function (args) {
+        return new timeoutStatement(args);
+        };
+
+        /**
+        * creates forkJoinStatement
+        * @param args
+        */
+        BallerinaASTFactory.createForkJoinStatement = function (args) {
+          return new forkJoinStatement(args);
         };
 
         /**

--- a/modules/web/js/ballerina/ast/defaults-added-ballerina-ast-factory.js
+++ b/modules/web/js/ballerina/ast/defaults-added-ballerina-ast-factory.js
@@ -168,5 +168,20 @@ define(['lodash', './ballerina-ast-factory'], function (_, BallerinaASTFactory) 
         return throwStatement;
     };
 
+    /**
+     * creates ForkJoinStatement
+     * @param args
+     */
+    DefaultsAddedBallerinaASTFactory.createForkJoinStatement = function (args) {
+        var forkJoinStatement = BallerinaASTFactory.createForkJoinStatement(args);
+        var forkStatement = BallerinaASTFactory.createForkStatement(args);
+        forkJoinStatement.addChild(forkStatement);
+        var joinStatement = BallerinaASTFactory.createJoinStatement(args);
+        forkJoinStatement.addChild(joinStatement);
+        var timeoutStatement = BallerinaASTFactory.createTimeoutStatement(args);
+        forkJoinStatement.addChild(timeoutStatement);
+        return forkJoinStatement;
+    };
+
     return DefaultsAddedBallerinaASTFactory;
 });

--- a/modules/web/js/ballerina/ast/module.js
+++ b/modules/web/js/ballerina/ast/module.js
@@ -28,7 +28,8 @@ define(['./ballerina-ast-factory', './ballerina-ast-root', './statements/conditi
         './statements/action-invocation-statement', './statements/variable-definition-statement','./resource-parameter',
         './return-type','./worker-invoke','./worker-receive','./statements/block-statement','./expressions/struct-field-access-expression',
         './expressions/variable-reference-expression','./expressions/reference-type-init-expression','./variable-definition', './statements/break-statement',
-        './statements/comment-statement', './expressions/type-cast-expression'],
+        './statements/comment-statement', './expressions/type-cast-expression',
+        './statements/fork-statement', './statements/join-statement', './statements/timeout-statement', './statements/forkjoin-statement'],
     function (BallerinaASTFactory, BallerinaASTRoot, ConditionalStatement, ConnectorDeclaration, ConnectorDefinition,
               ConstantDefinition, Expression, FunctionDefinition, IfElseStatement, IfStatement, ElseStatement,
               ElseIfStatement, TryCatchStatement, TryStatement, CatchStatement, ASTNode, ReplyStatement,
@@ -39,7 +40,8 @@ define(['./ballerina-ast-factory', './ballerina-ast-root', './statements/conditi
               LeftOperandExpression, RightOperandExpression, ConnectorAction, StructDefinition,
               ActionInvocationStatement, VariableDefinitionStatement, ResourceParameter, ReturnType, WorkerInvoke,
               WorkerReceive, BlockStatement, StructFieldAccessExpression, VariableReferenceExpression,
-              ReferenceTypeInitExpression, VariableDefinition, BreakStatement, CommentStatement, TypeCastExpression) {
+              ReferenceTypeInitExpression, VariableDefinition, BreakStatement, CommentStatement, TypeCastExpression,
+              ForkStatement, JoinStatement, TimeoutStatement, ForkJoinStatement) {
 
         return  {
             BallerinaASTFactory: BallerinaASTFactory,
@@ -95,7 +97,10 @@ define(['./ballerina-ast-factory', './ballerina-ast-root', './statements/conditi
             VariableDefinition : VariableDefinition,
             BreakStatement : BreakStatement,
             CommentStatement : CommentStatement,
-            TypeCastExpression : TypeCastExpression
+            TypeCastExpression : TypeCastExpression,
+            ForkStatement: ForkStatement,
+            JoinStatement: JoinStatement,
+            TimeoutStatement: TimeoutStatement,
+            ForkJoinStatement: ForkJoinStatement
         }
     });
-

--- a/modules/web/js/ballerina/ast/statements/fork-statement.js
+++ b/modules/web/js/ballerina/ast/statements/fork-statement.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['lodash', 'log', './statement'], function (_, log, Statement) {
+
+    /**
+     * Class for try statement in ballerina.
+     * @constructor
+     */
+    var ForkStatement = function () {
+        Statement.call(this);
+        this.type = "ForkStatement";
+    };
+
+    ForkStatement.prototype = Object.create(Statement.prototype);
+    ForkStatement.prototype.constructor = ForkStatement;
+
+    ForkStatement.prototype.initFromJson = function (jsonNode) {
+        var self = this;
+        _.each(jsonNode.children, function (childNode) {
+            var child = self.getFactory().createFromJson(childNode);
+            self.addChild(child);
+            child.initFromJson(childNode);
+        });
+    };
+
+    return ForkStatement;
+});

--- a/modules/web/js/ballerina/ast/statements/fork-statement.js
+++ b/modules/web/js/ballerina/ast/statements/fork-statement.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,7 @@
 define(['lodash', 'log', './statement'], function (_, log, Statement) {
 
     /**
-     * Class for try statement in ballerina.
+     * Class for fork statement in ballerina.
      * @constructor
      */
     var ForkStatement = function () {

--- a/modules/web/js/ballerina/ast/statements/forkjoin-statement.js
+++ b/modules/web/js/ballerina/ast/statements/forkjoin-statement.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,11 +15,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-define(['lodash', 'log', './statement', './fork-statement', './join-statement', './timeout-statement'],
+define(['lodash', 'log', './statement', './join-statement', './timeout-statement'],
        function (_, log, Statement, ForkStatement, JoinStatement, TimeoutStatement) {
 
     /**
-     * Class for try-catch statement in ballerina.
+     * Class for fork-join statement in ballerina.
      * @constructor
      */
     var ForkJoinStatement = function (args) {
@@ -29,26 +29,6 @@ define(['lodash', 'log', './statement', './fork-statement', './join-statement', 
 
     ForkJoinStatement.prototype = Object.create(Statement.prototype);
     ForkJoinStatement.prototype.constructor = ForkJoinStatement;
-
-    /**
-     * setter for catch block exception
-     * @param exception
-     */
-    ForkJoinStatement.prototype.setExceptionType = function (exception, options) {
-        if (!_.isNil(exception)) {
-            this.setAttribute('_exceptionType', exception, options);
-        } else {
-            log.error("Cannot set undefined to the exception.");
-        }
-    };
-
-    /**
-    * getter for catch block exception type
-    */
-    ForkJoinStatement.prototype.getExceptionType = function() {
-        return this._exceptionType;
-    };
-
 
     ForkJoinStatement.prototype.initFromJson = function (jsonNode) {
         var self = this;

--- a/modules/web/js/ballerina/ast/statements/forkjoin-statement.js
+++ b/modules/web/js/ballerina/ast/statements/forkjoin-statement.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['lodash', 'log', './statement', './fork-statement', './join-statement', './timeout-statement'],
+       function (_, log, Statement, ForkStatement, JoinStatement, TimeoutStatement) {
+
+    /**
+     * Class for try-catch statement in ballerina.
+     * @constructor
+     */
+    var ForkJoinStatement = function (args) {
+        Statement.call(this);
+        this.type = "ForkJoinStatement";
+    };
+
+    ForkJoinStatement.prototype = Object.create(Statement.prototype);
+    ForkJoinStatement.prototype.constructor = ForkJoinStatement;
+
+    /**
+     * setter for catch block exception
+     * @param exception
+     */
+    ForkJoinStatement.prototype.setExceptionType = function (exception, options) {
+        if (!_.isNil(exception)) {
+            this.setAttribute('_exceptionType', exception, options);
+        } else {
+            log.error("Cannot set undefined to the exception.");
+        }
+    };
+
+    /**
+    * getter for catch block exception type
+    */
+    ForkJoinStatement.prototype.getExceptionType = function() {
+        return this._exceptionType;
+    };
+
+
+    ForkJoinStatement.prototype.initFromJson = function (jsonNode) {
+        var self = this;
+        _.each(jsonNode.children, function (childNode) {
+            var child = self.getFactory().createFromJson(childNode);
+            self.addChild(child);
+            child.initFromJson(childNode);
+        });
+    };
+
+    return ForkJoinStatement;
+});

--- a/modules/web/js/ballerina/ast/statements/join-statement.js
+++ b/modules/web/js/ballerina/ast/statements/join-statement.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['lodash', 'log', './conditional-statement'], function (_, log, ConditionalStatement) {
+
+    /**
+     * Class for catch statement in ballerina.
+     * @class CatchStatement
+     * @constructor
+     * @extends ConditionalStatement
+     */
+    var JoinStatement = function (args) {
+        ConditionalStatement.call(this);
+        this._parameter = _.get(args, "parameter", "exception e");
+
+        this.type = "JoinStatement";
+    };
+
+    JoinStatement.prototype = Object.create(ConditionalStatement.prototype);
+    JoinStatement.prototype.constructor = JoinStatement;
+
+    JoinStatement.prototype.setParameter = function (parameter, options) {
+        if (!_.isNil(parameter)) {
+            this.setAttribute('_parameter', parameter, options);
+        }
+    };
+
+    JoinStatement.prototype.getParameter = function () {
+        return this._parameter;
+    };
+
+    JoinStatement.prototype.initFromJson = function (jsonNode) {
+        var self = this;
+        _.each(jsonNode.children, function (childNode) {
+            var child = self.getFactory().createFromJson(childNode);
+            self.addChild(child);
+            child.initFromJson(childNode);
+        });
+    };
+
+    return JoinStatement;
+});

--- a/modules/web/js/ballerina/ast/statements/join-statement.js
+++ b/modules/web/js/ballerina/ast/statements/join-statement.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,14 @@
 define(['lodash', 'log', './conditional-statement'], function (_, log, ConditionalStatement) {
 
     /**
-     * Class for catch statement in ballerina.
-     * @class CatchStatement
+     * Class for join statement in ballerina.
+     * @class JoinStatement
      * @constructor
      * @extends ConditionalStatement
      */
     var JoinStatement = function (args) {
         ConditionalStatement.call(this);
-        this._parameter = _.get(args, "parameter", "exception e");
+        this._parameter = _.get(args, "parameter", "");
 
         this.type = "JoinStatement";
     };

--- a/modules/web/js/ballerina/ast/statements/timeout-statement.js
+++ b/modules/web/js/ballerina/ast/statements/timeout-statement.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,14 @@
 define(['lodash', 'log', './conditional-statement'], function (_, log, ConditionalStatement) {
 
     /**
-     * Class for catch statement in ballerina.
-     * @class CatchStatement
+     * Class for timeout statement in ballerina.
+     * @class TimeoutStatement
      * @constructor
      * @extends ConditionalStatement
      */
     var TimeoutStatement = function (args) {
         ConditionalStatement.call(this);
-        this._parameter = _.get(args, "parameter", "exception e");
+        this._parameter = _.get(args, "parameter", "");
 
         this.type = "TimeoutStatement";
     };

--- a/modules/web/js/ballerina/ast/statements/timeout-statement.js
+++ b/modules/web/js/ballerina/ast/statements/timeout-statement.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['lodash', 'log', './conditional-statement'], function (_, log, ConditionalStatement) {
+
+    /**
+     * Class for catch statement in ballerina.
+     * @class CatchStatement
+     * @constructor
+     * @extends ConditionalStatement
+     */
+    var TimeoutStatement = function (args) {
+        ConditionalStatement.call(this);
+        this._parameter = _.get(args, "parameter", "exception e");
+
+        this.type = "TimeoutStatement";
+    };
+
+    TimeoutStatement.prototype = Object.create(ConditionalStatement.prototype);
+    TimeoutStatement.prototype.constructor = TimeoutStatement;
+
+    TimeoutStatement.prototype.setParameter = function (parameter, options) {
+        if (!_.isNil(parameter)) {
+            this.setAttribute('_parameter', parameter, options);
+        }
+    };
+
+    TimeoutStatement.prototype.getParameter = function () {
+        return this._parameter;
+    };
+
+    TimeoutStatement.prototype.initFromJson = function (jsonNode) {
+        var self = this;
+        _.each(jsonNode.children, function (childNode) {
+            var child = self.getFactory().createFromJson(childNode);
+            self.addChild(child);
+            child.initFromJson(childNode);
+        });
+    };
+
+    return TimeoutStatement;
+});

--- a/modules/web/js/ballerina/item-provider/initial-definitions.js
+++ b/modules/web/js/ballerina/item-provider/initial-definitions.js
@@ -209,10 +209,18 @@ define(['log', 'jquery', './../ast/ballerina-ast-factory', './../tool-palette/to
             nodeFactoryMethod: DefaultsAddedBallerinaASTFactory.createThrowStatement
         };
 
+        var createForkJoinStatementTool = {
+            id: "forkJoin",
+            name: "ForkJoin",
+            icon: "images/tool-icons/dgm-while.svg",
+            title: "Fork/Join",
+            nodeFactoryMethod: DefaultsAddedBallerinaASTFactory.createForkJoinStatement
+        };
+
         var statementToolDefArray = [createIfStatementTool, createAssignmentExpressionTool,
             createVariableDefinitionStatementTool,  createFunctionInvocationTool, createReturnStatementTool,
             createReplyStatementTool, createWhileStatementTool, createBreakStatementTool, createTryCatchStatementTool, createThrowStatementTool,
-            createWorkerInvocationStatementTool, createWorkerReceiverStatementTool];
+            createWorkerInvocationStatementTool, createWorkerReceiverStatementTool, createForkJoinStatementTool];
 
         // Create statements tool group
         var statements = new ToolGroup({

--- a/modules/web/js/ballerina/views/fork-statement-view.js
+++ b/modules/web/js/ballerina/views/fork-statement-view.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(
+    ['require', 'lodash', 'log', './block-statement-view', './../ast/statements/fork-statement'],
+    function (require, _, log, BlockStatementView, ForkStatement) {
+
+        /**
+         * The view to represent a Fork statement which is an AST visitor.
+         * @param {Object} args - Arguments for creating the view.
+         * @param {ForkStatement} args.model - The If statement model.
+         * @param {Object} args.container - The HTML container to which the view should be added to.
+         * @param {Object} args.parent - Parent Statement View, which in this case the fork-join statement
+         * @param {Object} [args.viewOptions={}] - Configuration values for the view.
+         * @class ForkStatementView
+         * @constructor
+         * @extends BlockStatementView
+         */
+        var ForkStatementView = function (args) {
+            _.set(args, "viewOptions.title.text", "Fork");
+            BlockStatementView.call(this, args);
+            this.getModel()._isChildOfWorker = args.isChildOfWorker;
+        };
+
+        ForkStatementView.prototype = Object.create(BlockStatementView.prototype);
+        ForkStatementView.prototype.constructor = ForkStatementView;
+
+        ForkStatementView.prototype.canVisitForkStatement = function(){
+            return true;
+        };
+
+        /**
+         * Set the fork statement model
+         * @param {ForkStatement} model
+         */
+        ForkStatementView.prototype.setModel = function (model) {
+            if (!_.isNil(model) && model instanceof ForkStatement) {
+                (this.__proto__.__proto__).setModel(model);
+            } else {
+                log.error("Fork statement definition is undefined or is of different type." + model);
+                throw "Fork statement definition is undefined or is of different type." + model;
+            }
+        };
+
+        ForkStatementView.prototype.initFromJson = function (jsonNode) {
+            var self = this;
+            _.each(jsonNode.children, function (childNode) {
+                var child = self.getFactory().createFromJson(childNode);
+                child.initFromJson(childNode);
+                self.addChild(child);
+            });
+        };
+
+        return ForkStatementView;
+    });

--- a/modules/web/js/ballerina/views/fork-statement-view.js
+++ b/modules/web/js/ballerina/views/fork-statement-view.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,7 +22,7 @@ define(
         /**
          * The view to represent a Fork statement which is an AST visitor.
          * @param {Object} args - Arguments for creating the view.
-         * @param {ForkStatement} args.model - The If statement model.
+         * @param {ForkStatement} args.model - The Fork statement model.
          * @param {Object} args.container - The HTML container to which the view should be added to.
          * @param {Object} args.parent - Parent Statement View, which in this case the fork-join statement
          * @param {Object} [args.viewOptions={}] - Configuration values for the view.

--- a/modules/web/js/ballerina/views/forkjoin-statement-view.js
+++ b/modules/web/js/ballerina/views/forkjoin-statement-view.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['require', 'lodash', 'log', './compound-statement-view', './../ast/statements/forkjoin-statement', './../ast/statements/join-statement',
+  './../ast/statements/timeout-statement', './point'],
+    function (require, _, log, CompoundStatementView, ForkJoinStatement, JoinStatement, TimeoutStatement, Point) {
+
+        /**
+         * The view to represent a Fork Join statement which is an AST visitor.
+         * @param {Object} args - Arguments for creating the view.
+         * @param {ForkJoinStatement} args.model - The Fork Join statement model.
+         * @param {Object} args.container - The HTML container to which the view should be added to.
+         * @param {Object} args.parent - Parent View (Resource, Worker, etc)
+         * @param {Object} [args.viewOptions={}] - Configuration values for the view.
+         * @class ForkJoinStatementView
+         * @constructor
+         * @extends CompoundStatementView
+         */
+        var ForkJoinStatementView = function (args) {
+            CompoundStatementView.call(this, args);
+
+            this._forkBlockView = undefined;
+            this._joinBlockView = undefined;
+            this._timeoutBlockView = undefined;
+            this.getModel()._isChildOfWorker = args.isChildOfWorker;
+
+            if (_.isNil(this._model) || !(this._model instanceof ForkJoinStatement)) {
+                log.error("Fork Join statement definition is undefined or is of different type." + this._model);
+                throw "Fork Join statement definition is undefined or is of different type." + this._model;
+            }
+
+            if (_.isNil(this._container)) {
+                log.error("Container for Fork Join statement is undefined." + this._container);
+                throw "Container for Fork Join statement is undefined." + this._container;
+            }
+        };
+
+        ForkJoinStatementView.prototype = Object.create(CompoundStatementView.prototype);
+        ForkJoinStatementView.prototype.constructor = ForkJoinStatementView;
+
+        ForkJoinStatementView.prototype.canVisitForkJoinStatement = function(){
+            return true;
+        };
+
+        /**
+         * Visit Fork Statement
+         * @param {ForkStatement} statement
+         */
+        ForkJoinStatementView.prototype.visitForkStatement = function(statement){
+            this._forkBlockView = this.visitChildStatement(statement);
+        };
+
+        /**
+         * Visit Join Statement
+         * @param {JoinStatement} statement
+         */
+        ForkJoinStatementView.prototype.visitJoinStatement = function(statement){
+            this._joinBlockView = this.visitChildStatement(statement);
+        };
+
+        /**
+         * Visit Timeout Statement
+         * @param {TimeoutStatement} statement
+         */
+        ForkJoinStatementView.prototype.visitTimeoutStatement = function(statement){
+            this._timeoutBlockView = this.visitChildStatement(statement);
+        };
+
+        ForkJoinStatementView.prototype.render = function (diagramRenderingContext) {
+            // Calling super render.
+            (this.__proto__.__proto__).render.call(this, diagramRenderingContext);
+
+            // Creating property pane
+            var model = this.getModel();
+            var editableProperty = {};
+            _.forEach(model.getChildren(), function (childStatement, index) {
+                if (childStatement instanceof JoinStatement) {
+                    editableProperty = {
+                        propertyType: "text",
+                        key: "Join parameter",
+                        model: childStatement,
+                        getterMethod: childStatement.getParameter
+                    };
+                    return false;
+                }
+            });
+            this._createPropertyPane({
+                                         model: model,
+                                         statementGroup: this.getStatementGroup(),
+                                         editableProperties: editableProperty
+                                     });
+            this._createDebugIndicator({
+                                           statementGroup: this.getStatementGroup()
+                                       });
+        };
+
+        /**
+         * Set the ForkJoinStatement model
+         * @param {ForkJoinStatement} model
+         */
+        ForkJoinStatementView.prototype.setModel = function (model) {
+            if (!_.isNil(model) && model instanceof ForkJoinStatement) {
+                (this.__proto__.__proto__).setModel(model);
+            } else {
+                log.error("Fork Join statement definition is undefined or is of different type." + model);
+                throw "Fork Join statement definition is undefined or is of different type." + model;
+            }
+        };
+
+        ForkJoinStatementView.prototype.getForkBlockView = function () {
+            return this._forkBlockView;
+        };
+
+        ForkJoinStatementView.prototype.getJoinBlockView = function () {
+            return this._joinBlockView;
+        };
+
+        ForkJoinStatementView.prototype.getTimeoutBlockView = function () {
+            return this._timeoutBlockView;
+        };
+
+        ForkJoinStatementView.prototype.onBeforeModelRemove = function () {
+            this.removeAllChildStatements();
+        };
+
+        ForkJoinStatementView.prototype._getEditPaneLocation = function () {
+            var statementBoundingBox = this.getJoinBlockView().getBoundingBox();
+            return new Point((statementBoundingBox.x()), (statementBoundingBox.y() - 1));
+        };
+
+        return ForkJoinStatementView;
+    });

--- a/modules/web/js/ballerina/views/forkjoin-statement-view.js
+++ b/modules/web/js/ballerina/views/forkjoin-statement-view.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/web/js/ballerina/views/join-statement-view.js
+++ b/modules/web/js/ballerina/views/join-statement-view.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(
+    ['require', 'lodash', 'log', './block-statement-view', './../ast/statements/join-statement'],
+    function (require, _, log, BlockStatementView, JoinStatement) {
+
+        /**
+         * The view to represent a Catch statement which is an AST visitor.
+         * @param {Object} args - Arguments for creating the view.
+         * @param {JoinStatement} args.model - The Fork Join statement model.
+         * @param {Object} args.container - The HTML container to which the view should be added to.
+         * @param {Object} args.parent - Parent Statement View, which in this case the fork-join statement
+         * @param {Object} [args.viewOptions={}] - Configuration values for the view.
+         * @class JoinStatementView
+         * @constructor
+         * @extends BlockStatementView
+         */
+        var JoinStatementView = function (args) {
+            _.set(args, "viewOptions.title.text", "Join");
+            BlockStatementView.call(this, args);
+            this.getModel()._isChildOfWorker = args.isChildOfWorker;
+        };
+
+        JoinStatementView.prototype = Object.create(BlockStatementView.prototype);
+        JoinStatementView.prototype.constructor = JoinStatementView;
+
+        JoinStatementView.prototype.canVisitJoinStatement = function(){
+            return true;
+        };
+
+        /**
+         * set the join statement model
+         * @param {JoinStatement} model
+         */
+        JoinStatementView.prototype.setModel = function (model) {
+            if (!_.isNil(model) && model instanceof JoinStatement) {
+                (this.__proto__.__proto__).setModel(model);
+            } else {
+                log.error("Fork Join statement definition is undefined or is of different type." + model);
+                throw "Fork Join statement definition is undefined or is of different type." + model;
+            }
+        };
+
+        JoinStatementView.prototype.render = function (diagramRenderingContext) {
+            // Calling super render.
+            (this.__proto__.__proto__).render.call(this, diagramRenderingContext);
+
+            this.listenTo(this._model, 'update-property-text', function(value, key){
+                this._model.setParameter(value);
+            });
+        };
+
+        return JoinStatementView;
+    });

--- a/modules/web/js/ballerina/views/join-statement-view.js
+++ b/modules/web/js/ballerina/views/join-statement-view.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,9 +20,9 @@ define(
     function (require, _, log, BlockStatementView, JoinStatement) {
 
         /**
-         * The view to represent a Catch statement which is an AST visitor.
+         * The view to represent a Join statement which is an AST visitor.
          * @param {Object} args - Arguments for creating the view.
-         * @param {JoinStatement} args.model - The Fork Join statement model.
+         * @param {JoinStatement} args.model - The join statement model.
          * @param {Object} args.container - The HTML container to which the view should be added to.
          * @param {Object} args.parent - Parent Statement View, which in this case the fork-join statement
          * @param {Object} [args.viewOptions={}] - Configuration values for the view.

--- a/modules/web/js/ballerina/views/statement-view-factory.js
+++ b/modules/web/js/ballerina/views/statement-view-factory.js
@@ -20,12 +20,13 @@ define(['lodash', 'log', 'event_channel', '../ast/module', './try-catch-statemen
         './else-if-statement-view', './assignment-view', './function-invocation-view',
         './action-invocation-statement-view', './while-statement-view', './reply-statement-view',
         './return-statement-view', './variable-definition-statement-view', './worker-invoke-view',
-        './worker-receive-view', './break-statement-view', './throw-statement-view'],
+        './worker-receive-view', './break-statement-view', './throw-statement-view',
+        './fork-statement-view', './join-statement-view', './timeout-statement-view', './forkjoin-statement-view'],
     function (_, log, EventChannel, AST, TryCatchStatementView, TryStatementView, CatchStatementView,
               IfElseStatementView, IfStatementView, ElseStatementView, ElseIfStatementView, AssignmentStatementView,
               FunctionInvocationStatementView, ActionInvocationStatementView, WhileStatementView, ReplyStatementView,
               ReturnStatement, VariableDefinitionStatementView, WorkerInvokeView, WorkerReceiveView, BreakStatementView,
-              ThrowStatementView) {
+              ThrowStatementView,ForkStatementView, JoinStatementView, TimeoutStatementView, ForkJoinStatementView) {
 
         var StatementViewFactory = function () {
         };
@@ -104,6 +105,14 @@ define(['lodash', 'log', 'event_channel', '../ast/module', './try-catch-statemen
                 return new WorkerReceiveView(args);
             } else if (statement instanceof AST.ThrowStatement) {
                 return new ThrowStatementView(args);
+            } else if (statement instanceof AST.ForkStatement) {
+                return new ForkStatementView(args);
+            } else if (statement instanceof AST.JoinStatement) {
+                return new JoinStatementView(args);
+            } else if (statement instanceof AST.TimeoutStatement) {
+                return new TimeoutStatementView(args);
+            } else if (statement instanceof AST.ForkJoinStatement) {
+                return new ForkJoinStatementView(args);
             }
         };
 

--- a/modules/web/js/ballerina/views/timeout-statement-view.js
+++ b/modules/web/js/ballerina/views/timeout-statement-view.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(
+    ['require', 'lodash', 'log', './block-statement-view', './../ast/statements/timeout-statement'],
+    function (require, _, log, BlockStatementView, TimeoutStatement) {
+
+        /**
+         * The view to represent a Timeout statement which is an AST visitor.
+         * @param {Object} args - Arguments for creating the view.
+         * @param {TimeoutStatement} args.model - The Fork Join statement model.
+         * @param {Object} args.container - The HTML container to which the view should be added to.
+         * @param {Object} args.parent - Parent Statement View, which in this case the fork-join statement
+         * @param {Object} [args.viewOptions={}] - Configuration values for the view.
+         * @class TimeoutStatementView
+         * @constructor
+         * @extends BlockStatementView
+         */
+        var TimeoutStatementView = function (args) {
+            _.set(args, "viewOptions.title.text", "Timeout");
+            BlockStatementView.call(this, args);
+            this.getModel()._isChildOfWorker = args.isChildOfWorker;
+        };
+
+        TimeoutStatementView.prototype = Object.create(BlockStatementView.prototype);
+        TimeoutStatementView.prototype.constructor = TimeoutStatementView;
+
+        TimeoutStatementView.prototype.canVisitTimeoutStatement = function(){
+            return true;
+        };
+
+        /**
+         * set the join statement model
+         * @param {TimeoutStatement} model
+         */
+        TimeoutStatementView.prototype.setModel = function (model) {
+            if (!_.isNil(model) && model instanceof TimeoutStatement) {
+                (this.__proto__.__proto__).setModel(model);
+            } else {
+                log.error("Fork Join statement definition is undefined or is of different type." + model);
+                throw "Fork Join statement definition is undefined or is of different type." + model;
+            }
+        };
+
+        TimeoutStatementView.prototype.render = function (diagramRenderingContext) {
+            // Calling super render.
+            (this.__proto__.__proto__).render.call(this, diagramRenderingContext);
+
+            this.listenTo(this._model, 'update-property-text', function(value, key){
+                this._model.setParameter(value);
+            });
+        };
+
+        return TimeoutStatementView;
+    });

--- a/modules/web/js/ballerina/views/timeout-statement-view.js
+++ b/modules/web/js/ballerina/views/timeout-statement-view.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,7 +22,7 @@ define(
         /**
          * The view to represent a Timeout statement which is an AST visitor.
          * @param {Object} args - Arguments for creating the view.
-         * @param {TimeoutStatement} args.model - The Fork Join statement model.
+         * @param {TimeoutStatement} args.model - The Timeout statement model.
          * @param {Object} args.container - The HTML container to which the view should be added to.
          * @param {Object} args.parent - Parent Statement View, which in this case the fork-join statement
          * @param {Object} [args.viewOptions={}] - Configuration values for the view.
@@ -44,7 +44,7 @@ define(
         };
 
         /**
-         * set the join statement model
+         * set the timeout statement model
          * @param {TimeoutStatement} model
          */
         TimeoutStatementView.prototype.setModel = function (model) {

--- a/modules/web/js/ballerina/visitors/source-gen/fork-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/fork-statement-visitor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/web/js/ballerina/visitors/source-gen/fork-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/fork-statement-visitor.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['require', 'lodash', 'log', 'event_channel', './abstract-statement-source-gen-visitor'], function (require, _, log, EventChannel, AbstractStatementSourceGenVisitor) {
+
+    var ForkStatementVisitor = function (parent) {
+        AbstractStatementSourceGenVisitor.call(this, parent);
+    };
+
+    ForkStatementVisitor.prototype = Object.create(AbstractStatementSourceGenVisitor.prototype);
+    ForkStatementVisitor.prototype.constructor = ForkStatementVisitor;
+
+    ForkStatementVisitor.prototype.canVisitForkStatement = function (forkStatement) {
+        return true;
+    };
+
+    ForkStatementVisitor.prototype.beginVisitForkStatement = function (forkStatement) {
+        //TODO Need to read input parameter for the fork statement dynamically
+        // this.appendSource('fork (' + forkStatement.getParameter() + '){');
+        this.appendSource('fork (message m){');
+        log.debug('Begin Visit Fork Statement');
+    };
+
+    ForkStatementVisitor.prototype.visitForkStatement = function (forkStatement) {
+        log.debug('Visit Fork Statement');
+    };
+
+    ForkStatementVisitor.prototype.endVisitForkStatement = function (forkStatement) {
+        this.appendSource("}\n");
+        this.getParent().appendSource(this.getGeneratedSource());
+        log.debug('End Visit Fork Statement');
+    };
+
+    ForkStatementVisitor.prototype.visitStatement = function(statement){
+        var StatementVisitorFactory = require('./statement-visitor-factory');
+        var statementVisitorFactory = new StatementVisitorFactory();
+        var statementVisitor = statementVisitorFactory.getStatementVisitor(statement, this);
+        statement.accept(statementVisitor);
+    };
+
+    return ForkStatementVisitor;
+});

--- a/modules/web/js/ballerina/visitors/source-gen/forkjoin-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/forkjoin-statement-visitor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/web/js/ballerina/visitors/source-gen/forkjoin-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/forkjoin-statement-visitor.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['require', 'lodash', 'log', 'event_channel', './abstract-statement-source-gen-visitor'], function(require, _, log, EventChannel, AbstractStatementSourceGenVisitor) {
+
+    var ForkJoinStatementVisitor = function(parent){
+        AbstractStatementSourceGenVisitor.call(this, parent);
+    };
+
+    ForkJoinStatementVisitor.prototype = Object.create(AbstractStatementSourceGenVisitor.prototype);
+    ForkJoinStatementVisitor.prototype.constructor = ForkJoinStatementVisitor;
+
+    ForkJoinStatementVisitor.prototype.canVisitStatement = function(statement){
+        return true;
+    };
+
+    ForkJoinStatementVisitor.prototype.visitForkStatement = function(statement){
+        var StatementVisitorFactory = require('./statement-visitor-factory');
+        var statementVisitorFactory = new StatementVisitorFactory();
+        var statementVisitor = statementVisitorFactory.getStatementVisitor(statement, this);
+        statement.accept(statementVisitor);
+    };
+
+    ForkJoinStatementVisitor.prototype.visitJoinStatement = function(statement){
+        var StatementVisitorFactory = require('./statement-visitor-factory');
+        var statementVisitorFactory = new StatementVisitorFactory();
+        var statementVisitor = statementVisitorFactory.getStatementVisitor(statement, this);
+        statement.accept(statementVisitor);
+    };
+
+    ForkJoinStatementVisitor.prototype.visitTimeoutStatement = function(statement){
+        var StatementVisitorFactory = require('./statement-visitor-factory');
+        var statementVisitorFactory = new StatementVisitorFactory();
+        var statementVisitor = statementVisitorFactory.getStatementVisitor(statement, this);
+        statement.accept(statementVisitor);
+    };
+
+    return ForkJoinStatementVisitor;
+});

--- a/modules/web/js/ballerina/visitors/source-gen/join-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/join-statement-visitor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/web/js/ballerina/visitors/source-gen/join-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/join-statement-visitor.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['require', 'lodash', 'log', 'event_channel', './abstract-statement-source-gen-visitor'], function (require, _, log, EventChannel, AbstractStatementSourceGenVisitor) {
+
+    var JoinStatementVisitor = function (parent) {
+        AbstractStatementSourceGenVisitor.call(this, parent);
+    };
+
+    JoinStatementVisitor.prototype = Object.create(AbstractStatementSourceGenVisitor.prototype);
+    JoinStatementVisitor.prototype.constructor = JoinStatementVisitor;
+
+    JoinStatementVisitor.prototype.canVisitJoinStatement = function (joinStatement) {
+        return true;
+    };
+
+    JoinStatementVisitor.prototype.beginVisitJoinStatement = function (joinStatement) {
+        //TODO Need to read join condition and aggregatedResponse dynamically
+        this.appendSource('join (all) (message[] aggregatedResponse){');
+        log.debug('Begin Visit Join Statement');
+    };
+
+    JoinStatementVisitor.prototype.visitJoinStatement = function (joinStatement) {
+        log.debug('Visit Join Statement');
+    };
+
+    JoinStatementVisitor.prototype.endVisitJoinStatement = function (joinStatement) {
+        this.appendSource("}\n");
+        this.getParent().appendSource(this.getGeneratedSource());
+        log.debug('End Visit Join Statement');
+    };
+
+    JoinStatementVisitor.prototype.visitStatement = function (statement) {
+        var StatementVisitorFactory = require('./statement-visitor-factory');
+        var statementVisitorFactory = new StatementVisitorFactory();
+        var statementVisitor = statementVisitorFactory.getStatementVisitor(statement, this);
+        statement.accept(statementVisitor);
+    };
+
+    return JoinStatementVisitor;
+});

--- a/modules/web/js/ballerina/visitors/source-gen/statement-visitor-factory.js
+++ b/modules/web/js/ballerina/visitors/source-gen/statement-visitor-factory.js
@@ -22,13 +22,15 @@ define(['lodash', 'log', 'event_channel', '../../ast/module', './try-catch-state
         './return-statement-visitor', './function-invocation-visitor', './function-invocation-expression-visitor',
         './assignment-visitor', './left-operand-expression-visitor', './right-operand-expression-visitor',
         './variable-definition-statement-visitor', './worker-invoke-visitor', './worker-receive-visitor',
-        './break-statement-visitor', './throw-statement-visitor', './comment-statement-visitor'],
+        './break-statement-visitor', './throw-statement-visitor', './comment-statement-visitor',
+        './fork-statement-visitor', './join-statement-visitor', './timeout-statement-visitor', './forkjoin-statement-visitor'],
 function (_, log, EventChannel, AST, TryCatchStatementVisitor, TryStatementVisitor, CatchStatementVisitor,
           IfElseStatementVisitor, IfStatementVisitor, ElseStatementVisitor, ElseIfStatementVisitor,
           WhileStatementVisitor, AssignmentStatementVisitor, ActionInvocationStatementVisitor, ReplyStatementVisitor,
           ReturnStatementVisitor, FunctionInvocationVisitor, FunctionInvocationExpressionVisitor, AssignmentVisitor,
           LeftOperandExpressionVisitor, RightOperandExpressionVisitor, VariableDefinitionStatement, WorkerInvoke,
-          WorkerReceive, BreakStatementVisitor, ThrowStatementVisitor, CommentStatementVisitor) {
+          WorkerReceive, BreakStatementVisitor, ThrowStatementVisitor, CommentStatementVisitor,
+          ForkStatementVisitor, JoinStatementVisitor, TimeoutStatementVisitor, ForkJoinStatementVisitor) {
 
     var StatementVisitorFactor = function () {
     };
@@ -78,6 +80,14 @@ function (_, log, EventChannel, AST, TryCatchStatementVisitor, TryStatementVisit
             return new ThrowStatementVisitor(parent);
         } else if (statement instanceof AST.CommentStatement) {
             return new CommentStatementVisitor(parent);
+        } else if (statement instanceof AST.ForkStatement) {
+            return new ForkStatementVisitor(parent.getParent());
+        } else if (statement instanceof AST.JoinStatement) {
+            return new JoinStatementVisitor(parent.getParent());
+        } else if (statement instanceof AST.TimeoutStatement) {
+            return new TimeoutStatementVisitor(parent.getParent());
+        } else if (statement instanceof AST.ForkJoinStatement) {
+            return new ForkJoinStatementVisitor(parent);
         }
     };
 

--- a/modules/web/js/ballerina/visitors/source-gen/timeout-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/timeout-statement-visitor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/web/js/ballerina/visitors/source-gen/timeout-statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/timeout-statement-visitor.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+define(['require', 'lodash', 'log', 'event_channel', './abstract-statement-source-gen-visitor'], function (require, _, log, EventChannel, AbstractStatementSourceGenVisitor) {
+
+    var TimeoutStatmentVisitor = function (parent) {
+        AbstractStatementSourceGenVisitor.call(this, parent);
+    };
+
+    TimeoutStatmentVisitor.prototype = Object.create(AbstractStatementSourceGenVisitor.prototype);
+    TimeoutStatmentVisitor.prototype.constructor = TimeoutStatmentVisitor;
+
+    TimeoutStatmentVisitor.prototype.canVisitTimeoutStatement = function (timeoutStatement) {
+        return true;
+    };
+
+    TimeoutStatmentVisitor.prototype.beginVisitTimeoutStatement = function (timeoutStatement) {
+        this.appendSource('timeout (30000) (message[] aggregatedResponse2){');
+        log.debug('Begin Visit Timeout Statement');
+    };
+
+    TimeoutStatmentVisitor.prototype.visitTimeoutStatement = function (timeoutStatement) {
+        log.debug('Visit Timeout Statement');
+    };
+
+    TimeoutStatmentVisitor.prototype.endVisitTimeoutStatement = function (timeoutStatement) {
+        this.appendSource("}\n");
+        this.getParent().appendSource(this.getGeneratedSource());
+        log.debug('End Visit Timeout Statement');
+    };
+
+    TimeoutStatmentVisitor.prototype.visitStatement = function (statement) {
+        var StatementVisitorFactory = require('./statement-visitor-factory');
+        var statementVisitorFactory = new StatementVisitorFactory();
+        var statementVisitor = statementVisitorFactory.getStatementVisitor(statement, this);
+        statement.accept(statementVisitor);
+    };
+
+    return TimeoutStatmentVisitor;
+});

--- a/modules/web/js/ballerina/visitors/statement-visitor.js
+++ b/modules/web/js/ballerina/visitors/statement-visitor.js
@@ -264,6 +264,46 @@ define(['lodash', 'log', './ast-visitor', '../ast/module'], function (_, log, AS
     StatementVisitor.prototype.endVisitCommentStatement = function (statement) {
     };
 
+    StatementVisitor.prototype.canVisitForkStatement = function (statement) {
+        return false;
+    };
+    StatementVisitor.prototype.beginVisitForkStatement = function (statement) {
+    };
+    StatementVisitor.prototype.visitForkStatement= function (statement) {
+    };
+    StatementVisitor.prototype.endVisitForkStatement = function (statement) {
+    };
+
+    StatementVisitor.prototype.canVisitJoinStatement = function (statement) {
+        return false;
+    };
+    StatementVisitor.prototype.beginVisitJoinStatement = function (statement) {
+    };
+    StatementVisitor.prototype.visitJoinStatement= function (statement) {
+    };
+    StatementVisitor.prototype.endVisitJoinStatement = function (statement) {
+    };
+
+    StatementVisitor.prototype.canVisitTimeoutStatement = function (statement) {
+        return false;
+    };
+    StatementVisitor.prototype.beginVisitTimeoutStatement = function (statement) {
+    };
+    StatementVisitor.prototype.visitTimeoutStatement= function (statement) {
+    };
+    StatementVisitor.prototype.endVisitTimeoutStatement = function (statement) {
+    };
+
+    StatementVisitor.prototype.canVisitForkJoinStatement = function (statement) {
+        return false;
+    };
+    StatementVisitor.prototype.beginVisitForkJoinStatement = function (statement) {
+    };
+    StatementVisitor.prototype.visitForkJoinStatement= function (statement) {
+    };
+    StatementVisitor.prototype.endVisitForkJoinStatement = function (statement) {
+    };
+
     /**
      * @param node {ASTNode}
      */
@@ -316,6 +356,14 @@ define(['lodash', 'log', './ast-visitor', '../ast/module'], function (_, log, AS
             return this.visitThrowStatement(node);
         }  else if (node instanceof AST.CommentStatement) {
             return this.visitCommentStatement(node);
+        }  else if (node instanceof AST.ForkStatement) {
+            return this.visitForkStatement(node);
+        }  else if (node instanceof AST.JoinStatement) {
+            return this.visitJoinStatement(node);
+        }  else if (node instanceof AST.TimeoutStatement) {
+            return this.visitTimeoutStatement(node);
+        }  else if (node instanceof AST.ForkJoinStatement) {
+            return this.visitForkJoinStatement(node);
         }
     };
 
@@ -371,6 +419,14 @@ define(['lodash', 'log', './ast-visitor', '../ast/module'], function (_, log, AS
             return this.canVisitThrowStatement(node);
         }  else if (node instanceof AST.CommentStatement) {
             return this.canVisitCommentStatement(node);
+        }  else if (node instanceof AST.ForkStatement) {
+            return this.canVisitForkStatement(node);
+        }  else if (node instanceof AST.JoinStatement) {
+            return this.canVisitJoinStatement(node);
+        }  else if (node instanceof AST.TimeoutStatement) {
+            return this.canVisitTimeoutStatement(node);
+        }  else if (node instanceof AST.ForkJoinStatement) {
+            return this.canVisitForkJoinStatement(node);
         }
     };
 
@@ -426,6 +482,14 @@ define(['lodash', 'log', './ast-visitor', '../ast/module'], function (_, log, AS
             return this.beginVisitThrowStatement(node);
         }  else if (node instanceof AST.CommentStatement) {
             return this.beginVisitCommentStatement(node);
+        }  else if (node instanceof AST.ForkStatement) {
+            return this.beginVisitForkStatement(node);
+        }  else if (node instanceof AST.JoinStatement) {
+            return this.beginVisitJoinStatement(node);
+        }  else if (node instanceof AST.TimeoutStatement) {
+            return this.beginVisitTimeoutStatement(node);
+        }  else if (node instanceof AST.ForkJoinStatement) {
+            return this.beginVisitForkJoinStatement(node);
         }
     };
 
@@ -481,6 +545,14 @@ define(['lodash', 'log', './ast-visitor', '../ast/module'], function (_, log, AS
             return this.endVisitThrowStatement(node);
         }  else if (node instanceof AST.CommentStatement) {
             return this.endVisitCommentStatement(node);
+        }  else if (node instanceof AST.ForkStatement) {
+            return this.endVisitForkStatement(node);
+        }  else if (node instanceof AST.JoinStatement) {
+            return this.endVisitJoinStatement(node);
+        }  else if (node instanceof AST.TimeoutStatement) {
+            return this.endVisitTimeoutStatement(node);
+        }  else if (node instanceof AST.ForkJoinStatement) {
+            return this.endVisitForkJoinStatement(node);
         }
     };
 


### PR DESCRIPTION
Fork/Join statement initial implementation consists of AST models, views and visitors required to visually implement ForkJoin statement inside the composer.