### PR TITLE
Install rimraf before clean lifecycle

### DIFF
--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -71,6 +71,22 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <!-- 'npm run clean' which is run in clean lifecycle needs 'rimraf' node module.
+                     Make sure it is installed  -->
+                    <execution>
+                      <id>npm install rimraf (clean)</id>
+                      <goals>
+                        <goal>exec</goal>
+                      </goals>
+                      <phase>pre-clean</phase>
+                      <configuration>
+                        <executable>npm</executable>
+                        <arguments>
+                          <argument>install</argument>
+                          <argument>rimraf</argument>
+                        </arguments>
+                      </configuration>
+                    </execution>
                     <execution>
                         <id>npm run clean (clean)</id>
                         <goals>


### PR DESCRIPTION
‘npm run clean’ which is run in the clean lifecycle depends on ‘rimraf’ node module. But when the project is just installed node modules are not installed yet. So need to install it pre-clean.