### PR TITLE
Create the img node for dragging at initialization and reuse to avoid duplication.

### DIFF
--- a/modules/web/js/ballerina/item-provider/initial-definitions.js
+++ b/modules/web/js/ballerina/item-provider/initial-definitions.js
@@ -26,7 +26,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createResourceDefTool = {
             id: "resource",
             name: "Resource",
-            icon: "images/tool-icons/resource.svg",
+            iconSrc: require("images/tool-icons/resource.svg"),
             title: "Resource",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createResourceDefinition
         };
@@ -34,7 +34,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createServiceDefTool = {
             id: "service",
             name: "Service",
-            icon: "images/tool-icons/service.svg",
+            iconSrc: require("images/tool-icons/service.svg"),
             title: "Service",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createServiceDefinition
         };
@@ -42,7 +42,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createFunctionDefTool = {
             id: "function",
             name: "Function",
-            icon: "images/tool-icons/function.svg",
+            iconSrc: require("images/tool-icons/function.svg"),
             title: "Function",
             nodeFactoryMethod:  BallerinaASTFactory.createFunctionDefinition
         };
@@ -59,7 +59,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
                     }
                 ]
             },
-            icon: "images/tool-icons/main-function.svg",
+            iconSrc: require("images/tool-icons/main-function.svg"),
             title: "Main Function",
             nodeFactoryMethod:  DefaultBallerinaASTFactory.createMainFunctionDefinition
         };
@@ -67,7 +67,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createConnectorDefTool = {
             id: "connectorDefinition",
             name: "Connector Definition",
-            icon: "images/tool-icons/connector.svg",
+            iconSrc: require("images/tool-icons/connector.svg"),
             title: "Connector Definition",
             nodeFactoryMethod:  DefaultBallerinaASTFactory.createConnectorDefinition
         };
@@ -75,7 +75,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createConnectorActionTool = {
             id: "connectorAction",
             name: "Connector Action",
-            icon: "images/tool-icons/action.svg",
+            iconSrc: require("images/tool-icons/action.svg"),
             title: "Connector Action",
             nodeFactoryMethod:  DefaultBallerinaASTFactory.createConnectorAction
         };
@@ -83,7 +83,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createStructsDefTool = {
             id: "struct",
             name: "Struct",
-            icon: "images/tool-icons/struct.svg",
+            iconSrc: require("images/tool-icons/struct.svg"),
             title: "Struct",
             nodeFactoryMethod: BallerinaASTFactory.createStructDefinition
         };
@@ -91,7 +91,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createTypeMapperDefTool = {
             id: "typeMapper",
             name: "Type Mapper",
-            icon: "images/tool-icons/type-converter.svg",
+            iconSrc: require("images/tool-icons/type-converter.svg"),
             title: "Type Mapper",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createTypeMapperDefinition
         };
@@ -99,7 +99,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createWorkerDecTool = {
             id: "worker",
             name: "Worker",
-            icon: "images/tool-icons/worker.svg",
+            iconSrc: require("images/tool-icons/worker.svg"),
             title: "Worker",
             nodeFactoryMethod: BallerinaASTFactory.createWorkerDeclaration
         };
@@ -118,7 +118,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createIfStatementTool = {
             id: "if",
             name: "If",
-            icon: "images/tool-icons/dgm-if-else.svg",
+            iconSrc: require("images/tool-icons/dgm-if-else.svg"),
             title: "If",
             nodeFactoryMethod: BallerinaASTFactory.createIfElseStatement
         };
@@ -126,7 +126,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createWhileStatementTool = {
             id: "while",
             name: "While",
-            icon: "images/tool-icons/dgm-while.svg",
+            iconSrc: require("images/tool-icons/dgm-while.svg"),
             title: "While",
             nodeFactoryMethod: BallerinaASTFactory.createWhileStatement
         };
@@ -134,7 +134,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createBreakStatementTool = {
             id: "break",
             name: "Break",
-            icon: "images/tool-icons/break.svg",
+            iconSrc: require("images/tool-icons/break.svg"),
             title: "Break",
             nodeFactoryMethod: BallerinaASTFactory.createBreakStatement
         };
@@ -142,7 +142,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createTryCatchStatementTool = {
             id: "try-catch",
             name: "Try-Catch",
-            icon: "images/tool-icons/try-catch.svg",
+            iconSrc: require("images/tool-icons/try-catch.svg"),
             title: "Try-Catch",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createTryCatchStatement
         };
@@ -150,7 +150,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createAssignmentExpressionTool = {
             id: "Assignment",
             name: "Assignment",
-            icon: "images/tool-icons/assign.svg",
+            iconSrc: require("images/tool-icons/assign.svg"),
             title: "Assignment",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createAggregatedAssignmentStatement
         };
@@ -159,7 +159,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createVariableDefinitionStatementTool = {
             id: "VariableDefinition",
             name: "VariableDefinition",
-            icon: "images/variable.svg",
+            iconSrc: require("images/variable.svg"),
             title: "Variable Definition",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createVariableDefinitionStatement
         };
@@ -167,7 +167,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createFunctionInvocationTool = {
             id: "FunctionInvocation",
             name: "FunctionInvocation",
-            icon: "images/tool-icons/function-invoke.svg",
+            iconSrc: require("images/tool-icons/function-invoke.svg"),
             title: "Function Invocation",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createAggregatedFunctionInvocationStatement
         };
@@ -175,7 +175,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createReplyStatementTool = {
             id: "Reply",
             name: "Reply",
-            icon: "images/tool-icons/reply.svg",
+            iconSrc: require("images/tool-icons/reply.svg"),
             title: "Reply",
             nodeFactoryMethod: BallerinaASTFactory.createReplyStatement
         };
@@ -183,7 +183,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createReturnStatementTool = {
             id: "Return",
             name: "Return",
-            icon: "images/tool-icons/return.svg",
+            iconSrc: require("images/tool-icons/return.svg"),
             title: "Return",
             nodeFactoryMethod: BallerinaASTFactory.createReturnStatement
         };
@@ -191,7 +191,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createWorkerInvocationStatementTool = {
             id: "WorkerInvocation",
             name: "Worker Invocation",
-            icon: "images/tool-icons/worker-invoke.svg",
+            iconSrc: require("images/tool-icons/worker-invoke.svg"),
             title: "Worker Invoke",
             nodeFactoryMethod: BallerinaASTFactory.createWorkerInvocationStatement
         };
@@ -199,7 +199,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createWorkerReplyStatementTool = {
             id: "WorkerReply",
             name: "Worker Reply",
-            icon: "images/tool-icons/worker-reply.svg",
+            iconSrc: require("images/tool-icons/worker-reply.svg"),
             title: "Worker Receive",
             nodeFactoryMethod: BallerinaASTFactory.createWorkerReplyStatement
         };
@@ -207,7 +207,7 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         var createThrowStatementTool = {
             id: "Throw",
             name: "Throw",
-            icon: "images/tool-icons/throw.svg",
+            iconSrc: require("images/tool-icons/throw.svg"),
             title: "Throw",
             nodeFactoryMethod: DefaultBallerinaASTFactory.createThrowStatement
         };
@@ -233,6 +233,12 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         //creating a one gourp for constructs
         var constructsToolDefArray = _.union(mainToolDefArray, [ seperator ] , statementToolDefArray);
 
+        constructsToolDefArray.forEach(tool => {
+            var icon = document.createElement('img');
+            icon.setAttribute('src', tool.iconSrc);
+            tool.icon = icon;
+        });
+
         var constructs = new ToolGroup({
             toolGroupName: "Constructs",
             toolGroupID: "constructs-tool-group",
@@ -241,6 +247,4 @@ import DefaultBallerinaASTFactory from '../ast/default-ballerina-ast-factory';
         });
 
         ToolPalette.push(constructs);
-
         export default ToolPalette;
-

--- a/modules/web/js/ballerina/item-provider/tool-palette-item-provider.js
+++ b/modules/web/js/ballerina/item-provider/tool-palette-item-provider.js
@@ -59,6 +59,19 @@ class ToolPaletteItemProvider extends EventChannel {
         // views added to tool palette for each imported package keyed by package name
         this._importedPackagesViews = {};
 
+        this.iconSrcs = {
+            function: require('images/tool-icons/function.svg'),
+            connector: require('images/tool-icons/connector.svg'),
+            action: require('images/tool-icons/action.svg'),
+        };
+
+        this.icons = {};
+        Object.keys(this.iconSrcs).forEach((iconName) => {
+            var icon = document.createElement('img');
+            icon.setAttribute('src', this.iconSrcs[iconName]);
+            this.icons[iconName] = icon;
+        });
+
         this.init();
     }
 
@@ -225,7 +238,7 @@ class ToolPaletteItemProvider extends EventChannel {
                 params: getParamString()
             };
             //TODO : use a generic icon
-            connector.icon = "images/tool-icons/connector.svg";
+            connector.icon = self.icons.connector;
             connector.title = connector.getName();
             connector.id = connector.getName();
             definitions.push(connector);
@@ -260,7 +273,8 @@ class ToolPaletteItemProvider extends EventChannel {
                     actionPackageName: packageName,
                     fullPackageName: pckg.getName()
                 };
-                action.icon = "images/tool-icons/action.svg";
+                action.icon = self.icons.action;
+
                 action.title = action.getName();
 
                 action.nodeFactoryMethod = DefaultBallerinaASTFactory.createAggregatedActionInvocationStatement;
@@ -277,7 +291,7 @@ class ToolPaletteItemProvider extends EventChannel {
                 });
             });
             connector.on('connector-action-added', function (action) {
-                var actionIcon = "images/tool-icons/action.svg";
+                var actionIcon = self.icons.action;
                 var toolGroupID = pckg.getName() + "-tool-group";
                 action.classNames = "tool-connector-action";
 
@@ -325,7 +339,8 @@ class ToolPaletteItemProvider extends EventChannel {
                 operandType: getReturnParamString(functionDef.getReturnParams()),
                 fullPackageName: pckg.getName()
             };
-            functionDef.icon = "images/tool-icons/function.svg";
+            functionDef.icon = self.icons.function;
+
             functionDef.title = functionDef.getName();
             functionDef.id = functionDef.getName();
             definitions.push(functionDef);
@@ -348,7 +363,7 @@ class ToolPaletteItemProvider extends EventChannel {
             var packageName = _.last(_.split(pckg.getName(), '.'));
             var nodeFactoryMethod = BallerinaASTFactory.createConnectorDeclaration;
             var toolGroupID = pckg.getName() + "-tool-group";
-            var icon = "images/tool-icons/connector.svg";
+            var icon = self.icons.connector;
 
             var getParamString = function() {
                 var params = _.map(connector.getParams(), function(p){return p.identifier});
@@ -377,7 +392,7 @@ class ToolPaletteItemProvider extends EventChannel {
             });
 
             connector.on('connector-action-added', function (action) {
-                var actionIcon = "images/tool-icons/action.svg";
+                var actionIcon = self.icons.action;
                 action.classNames = "tool-connector-action";
                 action.setId(action.getId());
                 var actionNodeFactoryMethod = DefaultBallerinaASTFactory.createAggregatedActionInvocationStatement;
@@ -424,7 +439,7 @@ class ToolPaletteItemProvider extends EventChannel {
                 functionName: functionDef.getName()
             };
             var toolGroupID = pckg.getName() + "-tool-group";
-            var icon = "images/tool-icons/function.svg";
+            var icon = self.icons.function;
             this.addToToolGroup(toolGroupID, functionDef, nodeFactoryMethod, icon);
 
             functionDef.on('name-modified', function(newName, oldName){

--- a/modules/web/js/ballerina/tool-palette/tool-view.js
+++ b/modules/web/js/ballerina/tool-palette/tool-view.js
@@ -26,11 +26,11 @@ import D3Utils from 'd3utils';
     var toolView = Backbone.View.extend({
 
         toolTemplate: _.template("<div id=\"<%=id%>\" class=\"tool-block tool-container <%=classNames%>\"  " +
-            "data-placement=\"bottom\" data-toggle=\"tooltip\" title='<%=title%>'> <img src=\"<%=icon%>\" " +
+            "data-placement=\"bottom\" data-toggle=\"tooltip\" title='<%=title%>'> <img src=\"<%=icon.getAttribute(\"src\")%>\" " +
             "class=\"tool-image\"  /><p class=\"tool-title\"><%=title%></p></div>"),
         toolTemplateVertical: _.template("<div id=\"<%=id%>-tool\" class=\"tool-block tool-container-vertical " +
             "<%=classNames%>\"> <div class=\"tool-container-vertical-icon\" data-placement=\"bottom\" " +
-            "data-toggle=\"tooltip\" title='<%=title%>'><img src=\"<%=icon%>\" class=\"tool-image\"  />" +
+            "data-toggle=\"tooltip\" title='<%=title%>'><img src=\"<%=icon.getAttribute(\"src\")%>\" class=\"tool-image\"  />" +
             "</div><div class=\"tool-container-vertical-title\" data-placement=\"bottom\" data-toggle=\"tooltip\" " +
             "title='<%=title%>'><%=title%></div><p class=\"tool-title\"><%=title%></p></div>"),
 
@@ -137,18 +137,15 @@ import D3Utils from 'd3utils';
         },
 
         createCloneCallback: function (view) {
-            var iconSVG,
+            var icon = this.model.icon,
                 self = this,
                 iconSize = _.get(this, 'options.dragIcon.box.size');
-            d3.xml(this.model.icon).mimeType("image/svg+xml").get(function (error, xml) {
-                if (error) throw error;
-                iconSVG = xml.getElementsByTagName("svg")[0];
-                d3.select(iconSVG).attr("width", iconSize).attr("height", iconSize);
-            });
+            var self = this;
+            d3.select(icon).attr("width", iconSize).attr("height", iconSize);
             function cloneCallBack() {
                 var div = view.createContainerForDraggable();
-                div.node().appendChild(iconSVG);
-                self._$draggedToolIcon = $(iconSVG);
+                div.node().appendChild(icon);
+                self._$draggedToolIcon = $(icon);
                 return div.node();
             }
 

--- a/modules/web/js/ballerina/tool-palette/tool.js
+++ b/modules/web/js/ballerina/tool-palette/tool.js
@@ -23,6 +23,7 @@ import Backbone from 'backbone';
         initialize: function (args) {
             this.name = _.get(args, 'name', null);
             this.icon = _.get(args, 'icon', null);
+            this.iconSrc = _.get(args, 'iconSrc', null);
             this.nodeFactoryMethod = _.get(args, 'nodeFactoryMethod', null);
             this.dragCursorOffset = _.get(args, 'dragCursorOffset', undefined);
             this.classNames = _.get(args, 'classNames', undefined);
@@ -80,4 +81,3 @@ import Backbone from 'backbone';
     });
 
     export default tool;
-

--- a/modules/web/webpack.config.js
+++ b/modules/web/webpack.config.js
@@ -46,7 +46,7 @@ var config = {
     node: { module: "empty", net: "empty", fs: "empty" },
     devtool: 'source-map',
     resolve: {
-        modules: [path.resolve('./lib'), path.resolve('./js'), path.resolve('./node_modules')],
+        modules: [path.resolve('./lib'), path.resolve('./js'), path.resolve('./node_modules'), path.resolve(__dirname)],
         alias: {
             /////////////////////////
             // third party modules //
@@ -91,7 +91,7 @@ var config = {
             workspace$: "workspace/module",
             ballerina$: "ballerina/module",
             "welcome-page$": "welcome-page/module",
-            jstree : "js-tree-v3.3.2/jstree.js"
+            jstree : "js-tree-v3.3.2/jstree.js",
         }
     }
 


### PR DESCRIPTION
Tool palette images are 'require'd with webpack so webpack optimizations also apply.