### PR TITLE
Add the root directory to storybook webpack module fallbacks so requiring '/images/name.svg' works

### DIFF
--- a/modules/web/.storybook/webpack.config.js
+++ b/modules/web/.storybook/webpack.config.js
@@ -7,17 +7,26 @@
 // to "React Create App". This only has babel loader to load JavaScript.
 const path = require('path');
 
-module.exports = {
-  plugins: [
-    // your custom plugins
-  ],
-  module: {
-    loaders: [
-      {
+// Export a function. Accept the base config as the only param.
+module.exports = function(storybookBaseConfig, configType) {
+  // configType has a value of 'DEVELOPMENT' or 'PRODUCTION'
+  // You can change the configuration based on that.
+  // 'PRODUCTION' is used when building the static version of storybook.
+
+  // Make whatever fine-grained changes you need
+  storybookBaseConfig.module.loaders = storybookBaseConfig.module.loaders.concat([{
         test: /\.css?$/,
         loaders: [ 'style', 'raw' ],
         include: path.resolve(__dirname, '../')
+      },
+      {
+        test: /\.(png|jpg|svg|cur|gif)$/,
+        loaders: [ 'file-loader' ]
       }
-    ]
-  },
+  ]);
+
+  storybookBaseConfig.resolve.fallback.push(path.resolve(__dirname, '../'))
+
+  // Return the altered config
+  return storybookBaseConfig;
 };

--- a/modules/web/js/ballerina/components/image-util.jsx
+++ b/modules/web/js/ballerina/components/image-util.jsx
@@ -1,15 +1,17 @@
-import path from 'path';
-
 // require all react images
 function requireAll(requireContext) {
     let components = {};
     requireContext.keys().map((item) => {
         var module = requireContext(item);
         if (module) {
-            components[path.basename(item, '.svg')] = module;
+            components[_getBasename(item, '.svg')] = module;
         }
     });
     return components;
+}
+
+function _getBasename(filename, ext) {
+    return filename.substring(2, filename.indexOf(ext));
 }
 
 const images = requireAll(require.context('images', true, /\.svg$/));


### PR DESCRIPTION
path node module does not seem to work with webpack 1 for some reason. had to remove it from image utils for now.