### PR TITLE
Renaming panel titles expands the input box accordingly

### DIFF
--- a/modules/web/js/ballerina/ast/connector-action.js
+++ b/modules/web/js/ballerina/ast/connector-action.js
@@ -68,6 +68,19 @@ class ConnectorAction extends ASTNode {
     }
 
     /**
+     * Set the Action name
+     * This is an alias to setActionName
+     * Many other node types' setters for name takes pattern `set<Node Type>Name`
+     * Node type of connector actions is ConnectorAction
+     * This method helps keep that formality so we can take advantage of it
+     * @param {string} name - Action Name
+     * @param {object} options - attribute options
+     */
+    setConnectorActionName(name, options) {
+        this.setActionName(name, options);
+    }
+
+    /**
      * Get the variable Declarations
      * @return {VariableDeclaration[]} variableDeclarations
      */
@@ -408,4 +421,3 @@ class ConnectorAction extends ASTNode {
 }
 
 export default ConnectorAction;
-

--- a/modules/web/js/ballerina/components/panel-decorator.jsx
+++ b/modules/web/js/ballerina/components/panel-decorator.jsx
@@ -49,6 +49,10 @@ class PanelDecorator extends React.Component {
     }
 
     onTitleClick() {
+        if(this.props.model.getType() === 'FunctionDefinition' && this.props.model.getFunctionName() === 'main') {
+            // should not edit main function name
+            return;
+        }
         this.setState({titleEditing: true})
     }
 

--- a/modules/web/js/ballerina/components/panel-decorator.jsx
+++ b/modules/web/js/ballerina/components/panel-decorator.jsx
@@ -95,10 +95,12 @@ class PanelDecorator extends React.Component {
                       className="headingRect" data-original-title="" title=""></rect>
                 <EditableText
                     x={bBox.x + titleHeight} y={bBox.y + titleHeight / 2 + annotationBodyHeight}
+                    width={this.props.model.viewState.titleWidth}
                     onBlur={() => { this.onTitleInputBlur() }}
                     onClick={() => { this.onTitleClick() }}
                     editing={this.state.titleEditing}
-                    onChange={e => {this.onTitleInputChange(e)}}>
+                    onChange={e => {this.onTitleInputChange(e)}}
+                    placeHolder={this.props.model.viewState.trimmedTitle}>
                     {this.props.title}
                 </EditableText>
                 <image x={bBox.x + 5} y={bBox.y + 5 + annotationBodyHeight} width={iconSize} height={iconSize}

--- a/modules/web/js/ballerina/visitors/dimension-calculator/annotation-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/annotation-definition-dimension-calculator-visitor.js
@@ -87,7 +87,9 @@ class AnnotationDefinitionDimensionCalculatorVisitor {
 
         viewState.components = components;
 
-        viewState.titleWidth = util.getTextWidth(node.getAnnotationName()).w;
+        const textWidth = util.getTextWidth(node.getAnnotationName());
+        viewState.titleWidth = textWidth.w;
+        viewState.trimmedTitle = textWidth.text;
 
         //// Creating components for parameters of the annotation
         // Creating component for opening bracket of the parameters view.

--- a/modules/web/js/ballerina/visitors/dimension-calculator/connector-action-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/connector-action-dimension-calculator-visitor.js
@@ -38,8 +38,6 @@ class ConnectorActionDimensionCalculatorVisitor {
         util.populatePanelDecoratorBBox(node, node.getActionName());
         let viewState = node.getViewState();
 
-        viewState.titleWidth = util.getTextWidth(node.getActionName()).w;
-
         //// Creating components for parameters of the connector action
         // Creating component for opening bracket of the parameters view.
         viewState.components.openingParameter = {};

--- a/modules/web/js/ballerina/visitors/dimension-calculator/connector-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/connector-definition-dimension-calculator-visitor.js
@@ -38,7 +38,9 @@ class ConnectorDefinitionDimensionCalculatorVisitor {
 
         let viewState = node.getViewState();
 
-        viewState.titleWidth = util.getTextWidth(node.getConnectorName()).w;
+        const textWidth = util.getTextWidth(node.getConnectorName());
+        viewState.titleWidth = textWidth.w;
+        viewState.trimmedTitle = textWidth.text;
 
         //// Creating components for parameters of the connector definition
         // Creating component for opening bracket of the parameters view.

--- a/modules/web/js/ballerina/visitors/dimension-calculator/function-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/function-definition-dimension-calculator-visitor.js
@@ -46,24 +46,24 @@ class FunctionDefinitionDimensionCalculatorVisitor {
         components['heading'].h = DesignerDefaults.panel.heading.height;
 
         let annotationHeight = 0;
- 
+
         /**
          * calculate the height of annotation view
          */
         let annotations = node.filterChildren(function (child) {
             return ASTFactory.isAnnotation(child)
         });
- 
+
         _.forEach(annotations, function (annotation) {
             annotationHeight = annotationHeight+ 25;
         });
- 
+
         components['annotation'] = new SimpleBBox();
- 
+
         if(node.viewState.annotationViewCollapsed){
-            components['annotation'].h = 25; 
+            components['annotation'].h = 25;
         }else{
-            components['annotation'].h = annotationHeight; 
+            components['annotation'].h = annotationHeight;
         }
 
         components['statementContainer'] = new SimpleBBox();
@@ -140,14 +140,15 @@ class FunctionDefinitionDimensionCalculatorVisitor {
 
         viewState.components = components;
 
-        viewState.titleWidth = util.getTextWidth(node.getFunctionName()).w;
-
+        const textWidth = util.getTextWidth(node.getFunctionName());
+        viewState.titleWidth = textWidth.w;
+        viewState.trimmedTitle = textWidth.text;
         //// Creating components for parameters of the function
         // Creating component for opening bracket of the parameters view.
         viewState.components.openingParameter = {};
         viewState.components.openingParameter.w = util.getTextWidth('(', 0).w;
 
-        // Creating component for closing bracket of the parameters view. 
+        // Creating component for closing bracket of the parameters view.
         viewState.components.closingParameter = {};
         viewState.components.closingParameter.w = util.getTextWidth(')', 0).w;
 
@@ -161,7 +162,7 @@ class FunctionDefinitionDimensionCalculatorVisitor {
         viewState.components.openingReturnType = {};
         viewState.components.openingReturnType.w = util.getTextWidth('(', 0).w;
 
-        // Creating component for closing bracket of the return types view. 
+        // Creating component for closing bracket of the return types view.
         viewState.components.closingReturnType = {};
         viewState.components.closingReturnType.w = util.getTextWidth(')', 0).w;
 

--- a/modules/web/js/ballerina/visitors/dimension-calculator/resource-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/resource-definition-dimension-calculator-visitor.js
@@ -44,14 +44,12 @@ class ResourceDefinitionDimensionCalculatorVisitor {
 
         let viewState = node.getViewState();
 
-        viewState.titleWidth = util.getTextWidth(node.getResourceName()).w;
-
         //// Creating components for parameters of the resource
         // Creating component for opening bracket of the parameters view.
         viewState.components.openingParameter = {};
         viewState.components.openingParameter.w = util.getTextWidth('(', 0).w;
 
-        // Creating component for closing bracket of the parameters view. 
+        // Creating component for closing bracket of the parameters view.
         viewState.components.closingParameter = {};
         viewState.components.closingParameter.w = util.getTextWidth(')', 0).w;
 

--- a/modules/web/js/ballerina/visitors/dimension-calculator/service-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/service-definition-dimension-calculator-visitor.js
@@ -41,7 +41,12 @@ class ServiceDefinitionDimensionCalculatorVisitor {
 
     endVisit(node) {
         util.populateOuterPanelDecoratorBBox(node);
-        
+
+        const viewState = node.viewState;
+
+        const textWidth = util.getTextWidth(node.getServiceName());
+        viewState.titleWidth = textWidth.w;
+        viewState.trimmedTitle = textWidth.text;
     }
 }
 

--- a/modules/web/js/ballerina/visitors/dimension-calculator/struct-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/struct-definition-dimension-calculator-visitor.js
@@ -49,6 +49,11 @@ class StructDefinitionDimensionCalculatorVisitor {
     endVisit(node) {
         util.populateOuterPanelDecoratorBBox(node);
         const viewState = node.getViewState();
+
+        const textWidth = util.getTextWidth(node.getStructName());
+        viewState.titleWidth = textWidth.w;
+        viewState.trimmedTitle = textWidth.text;
+
         const {components} = viewState;
         if(!node.viewState.collapsed){
             viewState.bBox.h += DesignerDefaults.panel.body.padding.top;

--- a/modules/web/js/ballerina/visitors/sizing-utils.js
+++ b/modules/web/js/ballerina/visitors/sizing-utils.js
@@ -239,7 +239,9 @@ class SizingUtil {
         viewState.bBox.h = components['heading'].h + components['body'].h + components['annotation'].h;
         viewState.bBox.w = components['body'].w;
 
-        viewState.titleWidth = util.getTextWidth(name).w;
+        const textWidth = util.getTextWidth(name);
+        viewState.titleWidth = textWidth.w;
+        viewState.trimmedTitle = textWidth.text;
 
         components['parametersPrefixContainer'] = {};
         components['parametersPrefixContainer'].w = util.getTextWidth('Parameters: ').w;


### PR DESCRIPTION
Further, long names are truncated and renaming of main function stopped.