### PR TITLE
Prevent values bleeding between EditableTexts of panel headers

### DIFF
--- a/modules/web/js/ballerina/components/editable-text.jsx
+++ b/modules/web/js/ballerina/components/editable-text.jsx
@@ -31,7 +31,7 @@ class EditableText extends React.Component {
 
     renderTextBox() {
         const {x, y, width, height = 25, onChange, onBlur, onKeyDown, children="",
-            className = 'text-input', placeHolder, canUpdate} = this.props;
+            className='text-input', placeholder} = this.props;
         const inputStyle = {
             position: 'absolute',
             top: y - height / 2,
@@ -44,40 +44,23 @@ class EditableText extends React.Component {
             inputStyle.display = 'none';
         }
 
-        let inputElement;
-        if (placeHolder || !canUpdate) {
-            inputElement = (
-            <input
-                className={className}
-                ref={input => {
-                        if (input !== null) {
-                        input.focus();
-                    }
-                }}
-                style={inputStyle}
-                onChange={onChange}
-                onKeyDown={onKeyDown}
-                onBlur={onBlur}
-                placeholder={placeHolder}
-            />
-        );
-        } else {
-            inputElement = (
-                <input
-                    className={className}
-                    ref={input => {
-                        if (input !== null) {
-                            input.focus();
-                        }
-                    }}
-                    style={inputStyle}
-                    onChange={onChange}
-                    onKeyDown={onKeyDown}
-                    onBlur={onBlur}
-                    value={children}
-                />
-            );
+        const inputProps = {
+            className,
+            ref: input => {
+                if (input !== null) {
+                    input.focus();
+                }
+            },
+            style: inputStyle,
+            onChange,
+            onKeyDown,
+            onBlur,
+            placeholder,
+            value: children
         }
+
+        const inputElement = <input {...inputProps} />
+
         ReactDOM.render(inputElement, this.context.overlay);
     }
 
@@ -104,16 +87,9 @@ class EditableText extends React.Component {
             dominantBaseline: 'central'
         };
 
-        if (this.props.placeHolder & this.props.canUpdate) {
-            return (
-                <text {...textProps} className="panel-label">{this.props.placeHolder}</text>
-            )
-        } else {
-            return (
-                <text {...textProps} className="panel-label">{this.props.children}</text>
-            )
-        }
-
+        return (
+            <text {...textProps} className="panel-label">{ this.props.displayText || this.props.children }</text>
+        );
     }
 }
 

--- a/modules/web/js/ballerina/components/utils/tag-component.jsx
+++ b/modules/web/js/ballerina/components/utils/tag-component.jsx
@@ -29,28 +29,28 @@ class TagController extends React.Component {
 
     constructor() {
         super();
-        this.state = {editing: false, editValue: DEFAULT_INPUT_VALUE};
+        this.state = {editing: false, editValue: ''};
     }
 
     onSelectClick() {
-        this.setState({editing: true, editValue: DEFAULT_INPUT_VALUE});
+        this.setState({editing: true, editValue: ''});
     }
 
     onEnter(input) {
         let setter = this.props.setter;
         setter(input);
-        this.setState({editing: false, editValue: DEFAULT_INPUT_VALUE});
+        this.setState({editing: false, editValue: ''});
     }
 
     onSelectBlur() {
-        this.setState({editing: false, editValue: DEFAULT_INPUT_VALUE});
+        this.setState({editing: false, editValue: ''});
     }
 
     /**
      * Click event handler for input
      * */
     onInputClick() {
-        this.setState({editing: true, editValue: DEFAULT_INPUT_VALUE});
+        this.setState({editing: true, editValue: ''});
     }
 
     /**
@@ -59,7 +59,7 @@ class TagController extends React.Component {
      * */
     onInputBlur(e) {
         e.target.value = "";
-        this.setState({editing: false, editValue: DEFAULT_INPUT_VALUE});
+        this.setState({editing: false, editValue: ''});
     }
 
     /**
@@ -68,14 +68,18 @@ class TagController extends React.Component {
      * */
     onKeyDown(e) {
         if (e.keyCode === 13) {
-            let setter = this.props.setter;
-            if (DEFAULT_INPUT_VALUE !== this.state.editValue) {
-                if (!setter(this.state.editValue)) {
-                    e.preventDefault();
-                }
+            let validate = this.props.validateInput;
+            let variableDeclaration = this.state.editValue.replace("=", "").replace(";", "");
+
+            if (!validate(variableDeclaration)) {
+                return;
             }
-            e.target.value = "";
-            this.setState({editing: false, editValue: DEFAULT_INPUT_VALUE});
+
+            let setter = this.props.setter;
+            if (!setter(this.state.editValue)) {
+                return;
+            }
+            this.setState({editing: false, editValue: ''});
         }
     }
 
@@ -84,12 +88,7 @@ class TagController extends React.Component {
      * @param {object} e - Event
      * */
     onInputChange(e) {
-        let validate = this.props.validateInput;
-        let variableDeclaration = e.target.value.replace("=", "");
-        variableDeclaration = variableDeclaration.replace(";", "");
-        if (validate(variableDeclaration)) {
-            this.setState({editing: true, editValue: variableDeclaration});
-        }
+        this.setState({editing: true, editValue: e.target.value});
     }
 
     render() {
@@ -157,14 +156,17 @@ class TagController extends React.Component {
                         <g>
                             <rect x={componentData.components.closingBracket.x - 100}
                                   y={componentData.components.closingBracket.y} width={90} height={25}
-                                  className="text-placeholder"/>
+                                  className="text-placeholder"
+                                  onClick={() => {
+                                      this.onInputClick()
+                                  }}/>
                             <EditableText x={componentData.components.closingBracket.x - 102}
                                           y={componentData.components.closingBracket.y + 25 / 2}
                                           width={93}
                                           height={26}
                                           className="tag-component-editable-text-box"
-                                          placeHolder={this.state.editValue}
-                                          canUpdate={false}
+                                          displayText={DEFAULT_INPUT_VALUE}
+                                          placeholder={DEFAULT_INPUT_VALUE}
                                           onKeyDown={e => {
                                               this.onKeyDown(e)
                                           }}
@@ -178,7 +180,7 @@ class TagController extends React.Component {
                                           onChange={e => {
                                               this.onInputChange(e)
                                           }}>
-                                + Add Value
+                                {this.state.editValue}
                             </EditableText>
                         </g>
                         <text x={componentData.components.closingBracket.x}
@@ -203,14 +205,17 @@ class TagController extends React.Component {
                         <g>
                             <rect x={componentData.components.closingBracket.x - 100}
                                   y={componentData.components.closingBracket.y} width={90} height={25}
-                                  className="text-placeholder"/>
+                                  className="text-placeholder"
+                                  onClick={() => {
+                                      this.onInputClick()
+                                  }}/>
                             <EditableText x={componentData.components.closingBracket.x - 102}
                                           y={componentData.components.closingBracket.y + 25 / 2}
                                           width={93}
                                           height={26}
                                           className="tag-component-editable-text-box"
-                                          placeHolder={this.state.editValue}
-                                          canUpdate={false}
+                                          displayText={DEFAULT_INPUT_VALUE}
+                                          placeholder={DEFAULT_INPUT_VALUE}
                                           onKeyDown={e => {
                                               this.onKeyDown(e);
                                           }}
@@ -224,7 +229,7 @@ class TagController extends React.Component {
                                           onChange={e => {
                                               this.onInputChange(e)
                                           }}>
-                                + Add Value
+                                {this.state.editValue}
                             </EditableText>
                         </g>
                         <text x={componentData.components.closingBracket.x}


### PR DESCRIPTION
panel title is upadated on enter instead of every key press