### PR TITLE
Add minifying back to production build and avoid mangling function names

### DIFF
--- a/modules/web/webpack.config.js
+++ b/modules/web/webpack.config.js
@@ -147,14 +147,20 @@ var config = {
 };
 
 if (process.env.NODE_ENV === 'production') {
+    config.plugins.push(new webpack.DefinePlugin({
+      PRODUCTION: JSON.stringify(true),
+
+      // React does some optimizations to it if NODE_ENV is set to 'production'
+      'process.env': {
+        NODE_ENV: JSON.stringify('production')
+      }
+    }));
+
   // Add UglifyJsPlugin only when we build for production.
   // uglyfying slows down webpack build so we avoid in when in development
-  /*config.plugins.push(new webpack.optimize.UglifyJsPlugin({
-    sourceMap: true
-  }));*/
-
-  config.plugins.push(new webpack.DefinePlugin({
-    PRODUCTION: JSON.stringify(true)
+  config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    sourceMap: true,
+    mangle: { keep_fnames: true}
   }));
 
 }else{


### PR DESCRIPTION
We use `constructor.name === 'SomeThing'` tests in our code to identify which class a certain object comes from. Such tests will fail when code is minified because function names are lost when mangling. This tells uglify plugin to avoid mangling function names.

React uses the presence of `process.env.NODE_ENV` set to `'production'` to remove warnings and stuff in production builds. So add that to define plugin.