### PR TITLE
Pass model prop to BlockStatementDecorator so ActionBox actions work for try catch and transaction statements

### DIFF
--- a/modules/web/js/ballerina/components/block-statement-decorator.jsx
+++ b/modules/web/js/ballerina/components/block-statement-decorator.jsx
@@ -87,7 +87,8 @@ class BlockStatementDecorator extends React.Component {
     }
 
     onDelete() {
-        this.props.model.remove();
+        const model = this.props.model || this.props.dropTarget;
+        model.remove();
     }
 
     onBreakpointClick() {
@@ -124,7 +125,8 @@ class BlockStatementDecorator extends React.Component {
     }
 
     render() {
-        const {bBox, title, dropTarget, expression, parameter, model} = this.props;
+        const {bBox, title, dropTarget, expression, parameter } = this.props;
+        const model = this.props.model || dropTarget;
 
         let title_h = blockStatement.heading.height;
         let title_w = blockStatement.heading.width;

--- a/modules/web/js/ballerina/components/transaction-statement.jsx
+++ b/modules/web/js/ballerina/components/transaction-statement.jsx
@@ -31,7 +31,7 @@ class TransactionStatement extends React.Component {
         let titleWidth = model.viewState.titleWidth;
         let children = getComponentForNodeArray(this.props.model.getChildren());
         return (<BlockStatementDecorator dropTarget={model} bBox={bBox} titleWidth={titleWidth}
-                                         title={"Transaction"}>
+                                         title={"Transaction"} model={model.parent}>
             {children}
         </BlockStatementDecorator>);
     }

--- a/modules/web/js/ballerina/components/try-statement.jsx
+++ b/modules/web/js/ballerina/components/try-statement.jsx
@@ -30,7 +30,7 @@ class TryStatement extends React.Component {
         let model = this.props.model,
             bBox = model.viewState.bBox;
         const children = getComponentForNodeArray(this.props.model.getChildren());
-        return (<BlockStatementDecorator dropTarget={model} bBox={bBox} title={"Try"}>
+        return (<BlockStatementDecorator dropTarget={model} bBox={bBox} title={"Try"} model={model.parent}>
             {children}
         </BlockStatementDecorator>);
     }


### PR DESCRIPTION
If model prop is not passed ActionBox uses dropTarget as the model