### PR TITLE
Fix reference type init expression unnecessary tree modified event

### DIFF
--- a/modules/web/js/ballerina/ast/expressions/key-value-expression.js
+++ b/modules/web/js/ballerina/ast/expressions/key-value-expression.js
@@ -40,10 +40,10 @@ class KeyValueExpression extends Expression {
      * @param {Object} jsonNode to initialize from
      */
     initFromJson(jsonNode) {
-        this.children = [];
+        this.getChildren().length = 0;
         _.each(jsonNode.children, (childNode) => {
             let child = this.getFactory().createFromJson(childNode);
-            this.addChild(child);
+            this.addChild(child, undefined, true, true);
             child.initFromJson(childNode);
         });
     }

--- a/modules/web/js/ballerina/ast/expressions/reference-type-init-expression.js
+++ b/modules/web/js/ballerina/ast/expressions/reference-type-init-expression.js
@@ -43,7 +43,7 @@ class ReferenceTypeInitExpression extends Expression {
         var self = this;
         _.each(jsonNode.children, function (childNode) {
             var child = self.getFactory().createFromJson(childNode);
-            self.addChild(child);
+            self.addChild(child, undefined, true, true);
             child.initFromJson(childNode);
         });
     }


### PR DESCRIPTION
When we are having a reference type init expression and if we edit it and focus out, an exception would be thrown. This is since when adding a child it by default fire the tree modified event. With the current implementation, we do need to trigger this event for inner types. We need to explicitly tell not to fire the events via the add child