### PR TITLE
Define magic numbers as constants

### DIFF
--- a/modules/web/js/ballerina/components/global-definitions.jsx
+++ b/modules/web/js/ballerina/components/global-definitions.jsx
@@ -17,65 +17,103 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import './global-definitions.css';
 import ImageUtil from './image-util';
 import { util as SizingUtils } from '../visitors/sizing-utils';
 import { variablesPane as variablesPaneDefaults } from '../configs/designer-defaults';
 
-export default class GlobalDefinitions extends React.Component {
+const GlobalDefinitions = ({ bBox, title, numberOfItems, onExpand }) => {
+    const headerHeight = variablesPaneDefaults.headerHeight;
+    const leftPadding = 10;
+    const iconSize = 20;
+    const iconLeftPadding = 12;
+    const globalsNoFontSize = 13;
+    const noOfGlobalsLeftPadding = 12;
+    const noOfGlobalsBGHeight = 18;
+    const noOfGlobalsTextPadding = 10;
+    const globalsLabelWidth = SizingUtils.getOnlyTextWidth(title);
 
-    render() {
-        const { bBox, title, numberOfItems, onExpand } = this.props;
+    const noOfGlobalsTextWidth = SizingUtils.getOnlyTextWidth(numberOfItems, { fontSize: globalsNoFontSize });
+    const noOfGlobalsBGWidth = Math.max(noOfGlobalsTextWidth + noOfGlobalsTextPadding, noOfGlobalsBGHeight);
 
-        const headerHeight = variablesPaneDefaults.headerHeight;
-        const leftPadding = 10;
-        const iconSize = 20;
-        const iconLeftPadding = 12;
-        const globalsNoFontSize = 13;
-        const noOfGlobalsLeftPadding = 12;
-        const noOfGlobalsBGHeight = 18;
-        const globalsLabelWidth = SizingUtils.getOnlyTextWidth(title);
+    const badgeWidth = leftPadding + globalsLabelWidth + noOfGlobalsLeftPadding + noOfGlobalsTextWidth +
+        iconLeftPadding + iconSize + leftPadding;
 
-        const noOfGlobalsTextWidth = SizingUtils.getOnlyTextWidth(numberOfItems, { fontSize: globalsNoFontSize });
-        const noOfGlobalsBGWidth = Math.max(noOfGlobalsTextWidth + 6, noOfGlobalsBGHeight);
+    const labelBbox = {
+        x: bBox.x + leftPadding,
+        y: bBox.y + (headerHeight / 2),
+    };
 
-        const badgeWidth = leftPadding + globalsLabelWidth + noOfGlobalsLeftPadding + noOfGlobalsTextWidth +
-            iconLeftPadding + iconSize + leftPadding;
+    const numberBbox = {
+        x: labelBbox.x + globalsLabelWidth + noOfGlobalsLeftPadding,
+        y: labelBbox.y,
+    };
 
-        const labelBbox = {
-            x: bBox.x + leftPadding,
-            y: bBox.y + headerHeight / 2,
-        };
+    const iconBbox = {
+        x: numberBbox.x + noOfGlobalsTextWidth + iconLeftPadding,
+        y: numberBbox.y - (iconSize / 2),
+    };
 
-        const numberBbox = {
-            x: labelBbox.x + globalsLabelWidth + noOfGlobalsLeftPadding,
-            y: labelBbox.y,
-        };
+    return (
+        <g className="package-definition-head" onClick={onExpand}>
+            <rect
+                x={bBox.x}
+                y={bBox.y}
+                width={badgeWidth}
+                height={headerHeight}
+                rx="0"
+                ry="0"
+                className="package-definition-header"
+            />
+            <rect
+                x={bBox.x}
+                y={bBox.y}
+                height={headerHeight}
+                className="global-definition-decorator"
+            />
+            <text x={labelBbox.x} y={labelBbox.y} rx="0" ry="0">
+                {title}
+            </text>
+            <rect
+                x={numberBbox.x - ((noOfGlobalsBGWidth - noOfGlobalsTextWidth) / 2)}
+                y={numberBbox.y - (noOfGlobalsBGHeight / 2)}
+                width={noOfGlobalsBGWidth}
+                height={noOfGlobalsBGHeight}
+                rx={noOfGlobalsBGHeight / 2}
+                ry={noOfGlobalsBGHeight / 2}
+                className="global-badge"
+            />
+            <text
+                x={numberBbox.x}
+                y={numberBbox.y}
+                rx="0"
+                ry="0"
+                style={{ fontSize: globalsNoFontSize }}
+                className="global-badge-text"
+            >
+                {numberOfItems}
+            </text>
+            <image
+                x={iconBbox.x}
+                y={iconBbox.y}
+                width={iconSize}
+                height={iconSize}
+                className="property-pane-action-button-delete"
+                xlinkHref={ImageUtil.getSVGIconString('view')}
+            />
+        </g>
+    );
+};
 
-        const iconBbox = {
-            x: numberBbox.x + noOfGlobalsTextWidth + iconLeftPadding,
-            y: numberBbox.y - iconSize / 2,
-        };
+GlobalDefinitions.propTypes = {
+    bBox: PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+    }).isRequired,
+    title: PropTypes.string.isRequired,
+    numberOfItems: PropTypes.number.isRequired,
+    onExpand: PropTypes.func.isRequired,
+};
 
-        return (
-            <g className="package-definition-head" onClick={(e) => { this.props.onExpand(e); }}>
-                <rect x={bBox.x} y={bBox.y} width={badgeWidth} height={headerHeight} rx="0" ry="0" className="package-definition-header" />
-                <rect x={bBox.x} y={bBox.y} height={headerHeight} className="global-definition-decorator" />
-                <text x={labelBbox.x} y={labelBbox.y} rx="0" ry="0">
-                    {title}
-                </text>
-                <rect
-                    x={numberBbox.x - (noOfGlobalsBGWidth - noOfGlobalsTextWidth) / 2} y={numberBbox.y - noOfGlobalsBGHeight / 2} width={noOfGlobalsBGWidth} height={noOfGlobalsBGHeight}
-                    rx={noOfGlobalsBGHeight / 2} ry={noOfGlobalsBGHeight / 2} className="global-badge"
-                />
-                <text x={numberBbox.x} y={numberBbox.y} rx="0" ry="0" style={{ fontSize: globalsNoFontSize }} className="global-badge-text">
-                    {numberOfItems}
-                </text>
-                <image
-                    width={iconSize} height={iconSize} className="property-pane-action-button-delete"
-                    xlinkHref={ImageUtil.getSVGIconString('view')} x={iconBbox.x} y={iconBbox.y}
-                />
-            </g>
-        );
-    }
-}
+export default GlobalDefinitions;

--- a/modules/web/js/ballerina/components/import-declaration.jsx
+++ b/modules/web/js/ballerina/components/import-declaration.jsx
@@ -17,65 +17,106 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import './import-declaration.css';
 import ImageUtil from './image-util';
-import { util as SizingUtils } from '../visitors/sizing-utils';
 
-export default class importDeclaration extends React.Component {
+const ImportDeclaration = ({ bBox, viewState, noOfImports, onClick }) => {
+    const {
+        headerHeight = 35,
+        leftPadding = 10,
+        iconSize = 20,
+        importNoFontSize = 13,
+        noOfImportsLeftPadding = 12,
+        iconLeftPadding = 12,
+        noOfImportsBGHeight = 18,
+        noOfImportsBGWidth = 18,
+        importLabelWidth = 48,
+        noOfImportsTextWidth = 100,
+        badgeWidth = 150,
+    } = viewState;
 
-    render() {
-        const bBox = this.props.bBox;
-        const headerHeight = 35;
-        const leftPadding = 10;
-        const iconSize = 20;
-        const importNoFontSize = 13;
-        const noOfImportsLeftPadding = 12;
-        const iconLeftPadding = 12;
-        const noOfImportsBGHeight = 18;
-        const importLabelWidth = 48.37;
+    const labelBbox = {
+        x: bBox.x + leftPadding,
+        y: bBox.y + (headerHeight / 2),
+    };
 
-        const noOfImports = this.props.imports.length;
+    const numberBbox = {
+        x: labelBbox.x + importLabelWidth + noOfImportsLeftPadding,
+        y: labelBbox.y,
+    };
 
-        const noOfImportsTextWidth = SizingUtils.getOnlyTextWidth(noOfImports, { fontSize: importNoFontSize });
-        const noOfImportsBGWidth = Math.max(noOfImportsTextWidth + 6, noOfImportsBGHeight);
+    const iconBbox = {
+        x: numberBbox.x + noOfImportsTextWidth + iconLeftPadding,
+        y: numberBbox.y - (iconSize / 2),
+    };
 
-        const badgeWidth = leftPadding + importLabelWidth + noOfImportsLeftPadding + noOfImportsTextWidth +
-                           iconLeftPadding + iconSize + leftPadding;
+    return (
+        <g className="package-definition-head" onClick={onClick}>
+            <rect
+                x={bBox.x}
+                y={bBox.y}
+                width={badgeWidth}
+                height={headerHeight}
+                rx="0"
+                ry="0"
+                className="package-definition-header"
+            />
+            <rect x={bBox.x} y={bBox.y} height={headerHeight} className="import-definition-decorator" />
+            <text x={labelBbox.x} y={labelBbox.y} rx="0" ry="0">
+                Imports
+            </text>
+            <rect
+                x={numberBbox.x - ((noOfImportsBGWidth - noOfImportsTextWidth) / 2)}
+                y={numberBbox.y - (noOfImportsBGHeight / 2)}
+                width={noOfImportsBGWidth}
+                height={noOfImportsBGHeight}
+                rx={noOfImportsBGHeight / 2}
+                ry={noOfImportsBGHeight / 2}
+                className="import-badge"
+            />
+            <text
+                x={numberBbox.x}
+                y={numberBbox.y}
+                rx="0"
+                ry="0"
+                style={{ fontSize: importNoFontSize }}
+                className="import-badge-text"
+            >
+                {noOfImports}
+            </text>
+            <image
+                width={iconSize}
+                height={iconSize}
+                className="property-pane-action-button-delete"
+                xlinkHref={ImageUtil.getSVGIconString('view')}
+                x={iconBbox.x}
+                y={iconBbox.y}
+            />
+        </g>
+    );
+};
 
-        const labelBbox = {
-            x: bBox.x + leftPadding,
-            y: bBox.y + headerHeight / 2,
-        };
+ImportDeclaration.propTypes = {
+    bBox: PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+    }).isRequired,
+    viewState: PropTypes.shape({
+        headerHeight: PropTypes.number,
+        leftPadding: PropTypes.number,
+        iconSize: PropTypes.number,
+        importNoFontSize: PropTypes.number,
+        noOfImportsLeftPadding: PropTypes.number,
+        iconLeftPadding: PropTypes.number,
+        noOfImportsBGHeight: PropTypes.number,
+        importLabelWidth: PropTypes.number,
+        noOfImportsTextWidth: PropTypes.number,
+        noOfImportsBGWidth: PropTypes.number,
+        badgeWidth: PropTypes.number,
+    }).isRequired,
+    noOfImports: PropTypes.number.isRequired,
+    onClick: PropTypes.func.isRequired,
+};
 
-        const numberBbox = {
-            x: labelBbox.x + importLabelWidth + noOfImportsLeftPadding,
-            y: labelBbox.y,
-        };
-
-        const iconBbox = {
-            x: numberBbox.x + noOfImportsTextWidth + iconLeftPadding,
-            y: numberBbox.y - iconSize / 2,
-        };
-
-        return (
-            <g className="package-definition-head" onClick={(e) => { this.props.onClick(e); }}>
-                <rect x={bBox.x} y={bBox.y} width={badgeWidth} height={headerHeight} rx="0" ry="0" className="package-definition-header" />
-                <rect x={bBox.x} y={bBox.y} height={headerHeight} className="import-definition-decorator" />
-                <text x={labelBbox.x} y={labelBbox.y} rx="0" ry="0">
-                    Imports
-                </text>
-                <rect
-                    x={numberBbox.x - (noOfImportsBGWidth - noOfImportsTextWidth) / 2} y={numberBbox.y - noOfImportsBGHeight / 2} width={noOfImportsBGWidth} height={noOfImportsBGHeight}
-                    rx={noOfImportsBGHeight / 2} ry={noOfImportsBGHeight / 2} className="import-badge"
-                />
-                <text x={numberBbox.x} y={numberBbox.y} rx="0" ry="0" style={{ fontSize: importNoFontSize }} className="import-badge-text">
-                    {noOfImports}
-                </text>
-                <image
-                    width={iconSize} height={iconSize} className="property-pane-action-button-delete"
-                    xlinkHref={ImageUtil.getSVGIconString('view')} x={iconBbox.x} y={iconBbox.y}
-                />
-            </g>
-        );
-    }
-}
+export default ImportDeclaration;

--- a/modules/web/js/ballerina/visitors/dimension-calculator/package-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/package-definition-dimension-calculator-visitor.js
@@ -16,6 +16,7 @@
  * under the License.
  */
 import { packageDefinition } from '../../configs/designer-defaults';
+import { util as SizingUtils } from '../sizing-utils';
 import ASTFactory from '../../ast/ballerina-ast-factory';
 
 /**
@@ -52,6 +53,50 @@ class PackageDefinitionDimensionCalculatorVisitor {
     visit() {
     }
 
+    _getImportDeclarationExpandedViewState() {
+        return {
+            importDeclarationHeight: 30,
+            importInputHeight: 40,
+            topBarHeight: 25,
+        };
+    }
+
+    _getImportDeclarationBadgeViewState(node) {
+        const headerHeight = 35;
+        const leftPadding = 10;
+        const iconSize = 20;
+        const importNoFontSize = 13;
+        const noOfImportsLeftPadding = 12;
+        const iconLeftPadding = 12;
+        const noOfImportsBGHeight = 18;
+        const importLabelWidth = 48.37;
+        const noOfImportsTextPadding = 10;
+
+        const imports = node.children.filter(c => c.constructor.name === 'ImportDeclaration');
+        const noOfImports = imports.length;
+
+        const noOfImportsTextWidth = SizingUtils.getOnlyTextWidth(noOfImports, { fontSize: importNoFontSize });
+        const noOfImportsBGWidth = Math.max(noOfImportsTextWidth + noOfImportsTextPadding, noOfImportsBGHeight);
+
+        const badgeWidth = leftPadding + importLabelWidth + noOfImportsLeftPadding + noOfImportsTextWidth +
+                           iconLeftPadding + iconSize + leftPadding;
+
+        return {
+            headerHeight,
+            leftPadding,
+            iconSize,
+            importNoFontSize,
+            noOfImportsLeftPadding,
+            iconLeftPadding,
+            noOfImportsBGHeight,
+            importLabelWidth,
+            noOfImportsTextPadding,
+            noOfImportsTextWidth,
+            noOfImportsBGWidth,
+            badgeWidth,
+        };
+    }
+
     /**
      * visit the visitor at the end.
      *
@@ -86,6 +131,10 @@ class PackageDefinitionDimensionCalculatorVisitor {
 
         viewState.bBox.h = height;
         viewState.bBox.w = 0;
+
+        viewState.components = viewState.components || {};
+        viewState.components.importDeclaration = this._getImportDeclarationBadgeViewState(node);
+        viewState.components.importsExpanded = this._getImportDeclarationExpandedViewState(node);
     }
 }
 


### PR DESCRIPTION
There were some numbers representing lengths of sub components of package definitions view that were hardcoded.
Defined them as constants. Also took the dimension constants to the dimension calc visitor so the parent viewfor package definition and imports know before hand the lenghts of sub components.