### PR TITLE
WS fixes and remove redundant location info in validate error msg

### DIFF
--- a/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BallerinaComposerErrorStrategy.java
+++ b/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BallerinaComposerErrorStrategy.java
@@ -54,8 +54,7 @@ public class BallerinaComposerErrorStrategy extends DefaultErrorStrategy {
         int position = missingSymbol.getCharPositionInLine();
         String mismatchedToken = getTokenErrorDisplay(e.getOffendingToken());
         String expectedToken = e.getExpectedTokens().toString(parser.getVocabulary());
-        String msg = getSourceLocation(parser, line, position) + "mismatched input " + mismatchedToken + ". Expecting" +
-                     " one of " + expectedToken;
+        String msg = "mismatched input " + mismatchedToken + ". Expecting" + " one of " + expectedToken;
         // FixMe: This need to be handled by grammar itself
         if (!EOF.equals(mismatchedToken)) {
             errorTokens.add(createError(line, position, msg));
@@ -70,8 +69,7 @@ public class BallerinaComposerErrorStrategy extends DefaultErrorStrategy {
         int line = missingSymbol.getLine();
         int position = getMissingSymbol(parser).getCharPositionInLine();
         String missingToken = expecting.toString(parser.getVocabulary());
-        String msg = getSourceLocation(parser, line, position) + "missing " + missingToken + " before " +
-                     getTokenErrorDisplay(token);
+        String msg = "missing " + missingToken + " before " + getTokenErrorDisplay(token);
         errorTokens.add(createError(line, position, msg));
     }
     
@@ -80,7 +78,7 @@ public class BallerinaComposerErrorStrategy extends DefaultErrorStrategy {
         Token token = parser.getCurrentToken();
         int line = getMissingSymbol(parser).getLine();
         int position = getMissingSymbol(parser).getCharPositionInLine();
-        String msg = getSourceLocation(parser, line, position) + "invalid identifier " + getTokenErrorDisplay(token);
+        String msg = "invalid identifier " + getTokenErrorDisplay(token);
         if (!EOF.equals(getTokenErrorDisplay(token))) {
             errorTokens.add(createError(line, position, msg));
         }
@@ -91,7 +89,7 @@ public class BallerinaComposerErrorStrategy extends DefaultErrorStrategy {
         Token token = parser.getCurrentToken();
         int line = getMissingSymbol(parser).getLine();
         int position = getMissingSymbol(parser).getCharPositionInLine();
-        String msg = getSourceLocation(parser, line, position) + "unwanted token " + getTokenErrorDisplay(token);
+        String msg = "unwanted token " + getTokenErrorDisplay(token);
         if (!EOF.equals(getTokenErrorDisplay(token))) {
             errorTokens.add(createError(line, position, msg));
         }

--- a/modules/web/js/ballerina/ast/connector-action.js
+++ b/modules/web/js/ballerina/ast/connector-action.js
@@ -146,14 +146,16 @@ class ConnectorAction extends ASTNode {
      * @return {string} - Return types.
      */
     getReturnTypesAsString() {
-        const returnTypes = [];
-        _.forEach(this.getReturnTypes(), (returnTypeChild, index) => {
-            let returnTypeTxt = (index !== 0 && returnTypeChild.whiteSpace.useDefault) ? ' ' : '';
-            returnTypeTxt += returnTypeChild.getParameterDefinitionAsString();
-            returnTypes.push(returnTypeTxt);
+        let returnTypesString = '';
+        this.getReturnTypes().forEach((returnType, index) => {
+            if (index !== 0) {
+                returnTypesString += ',';
+            }
+            returnTypesString += (returnType.whiteSpace.useDefault && index !== 0 ? ' '
+                                : returnType.getWSRegion(0));
+            returnTypesString += returnType.getParameterDefinitionAsString();
         });
-
-        return _.join(returnTypes, ',');
+        return returnTypesString;
     }
 
     /**
@@ -254,16 +256,15 @@ class ConnectorAction extends ASTNode {
      * @return {string} - Arguments as string.
      */
     getArgumentsAsString() {
-        let argsAsString = '';
-        const args = this.getArguments();
-        _.forEach(args, (argument, index) => {
-            argsAsString += argument.getTypeName() + ' ';
-            argsAsString += argument.getName();
-            if (args.length - 1 !== index) {
-                argsAsString += ' , ';
+        let argsString = '';
+        this.getArguments().forEach((arg, index) => {
+            if (index != 0 ) {
+                argsString += ',';
             }
+            argsString += (arg.whiteSpace.useDefault && index !== 0 ? ' ' : arg.getWSRegion(0))
+            argsString += arg.getParameterDefinitionAsString();
         });
-        return argsAsString;
+        return argsString;
     }
 
     /**

--- a/modules/web/js/ballerina/ast/connector-definition.js
+++ b/modules/web/js/ballerina/ast/connector-definition.js
@@ -104,12 +104,15 @@ class ConnectorDefinition extends ASTNode {
      * @return {string} - Arguments as string.
      */
     getArgumentsAsString() {
-        const argsStringArray = [];
-        const args = this.getArguments();
-        _.forEach(args, (arg) => {
-            argsStringArray.push(arg.getParameterDefinitionAsString());
+        let argsString = '';
+        this.getArguments().forEach((arg, index) => {
+            if (index != 0 ) {
+                argsString += ',';
+            }
+            argsString += (arg.whiteSpace.useDefault && index !== 0 ? ' ' : arg.getWSRegion(0))
+            argsString += arg.getParameterDefinitionAsString();
         });
-        return _.join(argsStringArray, ', ');
+        return argsString;
     }
 
 

--- a/modules/web/js/ballerina/ast/function-definition.js
+++ b/modules/web/js/ballerina/ast/function-definition.js
@@ -111,13 +111,15 @@ class FunctionDefinition extends CallableDefinition {
      * @return {string} - Arguments as string.
      */
     getArgumentsAsString() {
-        const argsStringArray = [];
-        const args = this.getArguments();
-        _.forEach(args, (arg) => {
-            argsStringArray.push(arg.getParameterDefinitionAsString());
+        let argsString = '';
+        this.getArguments().forEach((arg, index) => {
+            if (index !=0 ) {
+                argsString += ',';
+                argsString += (arg.whiteSpace.useDefault ? ' ' : arg.getWSRegion(0));
+            }
+            argsString += arg.getParameterDefinitionAsString();
         });
-
-        return _.join(argsStringArray, ', ');
+        return argsString;
     }
 
     /**

--- a/modules/web/js/ballerina/ast/function-definition.js
+++ b/modules/web/js/ballerina/ast/function-definition.js
@@ -163,12 +163,16 @@ class FunctionDefinition extends CallableDefinition {
      * @return {string} - Return types separated by comma.
      */
     getReturnTypesAsString() {
-        const returnTypes = [];
-        _.forEach(this.getReturnParameterDefinitionHolder().getChildren(), (returnType) => {
-            returnTypes.push(returnType.getParameterDefinitionAsString());
+        let returnTypesString = '';
+        this.getReturnTypes().forEach((returnType, index) => {
+            if (index != 0) {
+                returnTypesString += ',';
+                returnTypesString += (returnType.whiteSpace.useDefault ? ' '
+                                : returnType.getWSRegion(0));
+            }
+            returnTypesString += returnType.getParameterDefinitionAsString();
         });
-
-        return _.join(returnTypes, ', ');
+        return returnTypesString;
     }
 
     /**

--- a/modules/web/js/ballerina/ast/resource-definition.js
+++ b/modules/web/js/ballerina/ast/resource-definition.js
@@ -118,7 +118,8 @@ class ResourceDefinition extends ASTNode {
 
         _.forEach(params, (parameter, index) => {
             if (index != 0) {
-                paramsAsString += ((parameter.whiteSpace.useDefault) ? ', ' : ',');
+                paramsAsString += ((parameter.whiteSpace.useDefault) ? ', ' 
+                            : (',' + parameter.getWSRegion(0)));
             }
             paramsAsString += parameter.getParameterDefinitionAsString();
         });

--- a/modules/web/js/ballerina/visitors/source-gen/connector-definition-visitor.js
+++ b/modules/web/js/ballerina/visitors/source-gen/connector-definition-visitor.js
@@ -57,20 +57,9 @@ class ConnectorDefinitionVisitor extends AbstractSourceGenVisitor {
                 }
             });
 
-        let argumentsSrc = '';
-        _.forEach(connectorDefinition.getArguments(), (argument, index) => {
-            argumentsSrc += (index !== 0 && argument.whiteSpace.useDefault) ? ' ' : '';
-            argumentsSrc += argument.getWSRegion(0) + argument.getTypeName();
-            argumentsSrc += argument.getWSRegion(1) + argument.getName();
-            argumentsSrc += argument.getWSRegion(2);
-            if (connectorDefinition.getArguments().length - 1 !== index) {
-                argumentsSrc += ',';
-            }
-        });
-
         constructedSourceSegment += 'connector'
           + connectorDefinition.getWSRegion(0) + connectorDefinition.getConnectorName()
-          + connectorDefinition.getWSRegion(1) + '(' + argumentsSrc + ')'
+          + connectorDefinition.getWSRegion(1) + '(' + connectorDefinition.getArgumentsAsString() + ')'
           + connectorDefinition.getWSRegion(2) + '{' + connectorDefinition.getWSRegion(3);
         constructedSourceSegment += (useDefaultWS) ? this.getIndentation() : '';
         this.appendSource(constructedSourceSegment);


### PR DESCRIPTION
While showing errors in source view, we already mark
the relevant line with error symbol in gutter, also we already receive
location info in a separate property for each error entry
in validate response. Having location info prep-ended
to error msg is not necessary as user already know
the location of the error by looking at source view
error decorations.