### PR TITLE
console - wrap if text line too long

### DIFF
--- a/modules/web/js/debugger/debugger.css
+++ b/modules/web/js/debugger/debugger.css
@@ -183,6 +183,11 @@ table.debug-frames {
     line-height: 1.8;
     margin: 0;
     font-size: inherit;
+    white-space: pre-wrap;       /* css-3 */
+    white-space: -moz-pre-wrap;  /* Firefox */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
 #console .INFO { color: #03a9f4 !important; }


### PR DESCRIPTION
Word wrap If console output is too long. 