### PR TITLE
Fixing #2101, Backend errors are ignored.

### DIFF
--- a/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BLangFileRestService.java
+++ b/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BLangFileRestService.java
@@ -180,7 +180,11 @@ public class BLangFileRestService {
                 StringUtils.EMPTY);
         BLangAntlr4Listener ballerinaBaseListener = new BLangAntlr4Listener(bLangModelBuilder, filePath);
         ballerinaParser.addParseListener(ballerinaBaseListener);
-        ballerinaParser.compilationUnit();
+        try {
+            ballerinaParser.compilationUnit();
+        } catch (Exception e) {
+            logger.debug("Model building error", e);
+        }
 
         JsonArray errors = new JsonArray();
 


### PR DESCRIPTION
Core's parser is not robust enough to keep on parsing when there is an error. If and when, the runtime supports reporting multiple errors instead breaking on first this fix can be removed.

@sameera-jayasoma please note.