### PR TITLE
Global constant definitions rhs can be an expression

### DIFF
--- a/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BLangJSONModelBuilder.java
+++ b/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BLangJSONModelBuilder.java
@@ -1732,7 +1732,22 @@ public class BLangJSONModelBuilder implements NodeVisitor {
         this.addWhitespaceDescriptor(constantDefinitionObj, constantDefinition.getWhiteSpaceDescriptor());
         constantDefinitionObj.addProperty(BLangJSONModelConstants.DEFINITION_TYPE, BLangJSONModelConstants
                 .CONSTANT_DEFINITION);
-        constantDefinition.getVariableDefStmt().accept(this);
+        tempJsonArrayRef.push(new JsonArray());
+
+        constantDefinitionObj.addProperty(BLangJSONModelConstants.CONSTANT_DEFINITION_BTYPE,
+                constantDefinition.getTypeName().getName());
+        constantDefinitionObj.addProperty(BLangJSONModelConstants.CONSTANT_DEFINITION_IDENTIFIER,
+                constantDefinition.getName());
+
+        VariableDefStmt varDefStmt = constantDefinition.getVariableDefStmt();
+
+        if (varDefStmt.getRExpr() != null) {
+            varDefStmt.getRExpr().accept(this);
+        }
+        constantDefinitionObj.add(BLangJSONModelConstants.CHILDREN, tempJsonArrayRef.peek());
+
+        tempJsonArrayRef.pop();
+        tempJsonArrayRef.peek().add(constantDefinitionObj);
     }
 
     @Override

--- a/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BLangJSONModelConstants.java
+++ b/modules/services/workspace-service/src/main/java/org/ballerinalang/composer/service/workspace/rest/datamodel/BLangJSONModelConstants.java
@@ -65,6 +65,10 @@ public class BLangJSONModelConstants {
 
     public static final String CONSTANT_DEFINITION = "constant_definition";
 
+    public static final String CONSTANT_DEFINITION_BTYPE = "constant_definition_btype";
+
+    public static final String CONSTANT_DEFINITION_IDENTIFIER = "constant_definition_identifier";
+
     public static final String GLOBAL_VARIABLE_DEFINITION = "global_variable_definition";
 
     public static final String GLOBAL_VARIABLE_DEFINITION_BTYPE = "global_variable_definition_btype";

--- a/modules/web/js/ballerina/ast/constant-definition.js
+++ b/modules/web/js/ballerina/ast/constant-definition.js
@@ -59,11 +59,12 @@ class ConstantDefinition extends VariableDeclaration {
     getConstantDefinitionAsString() {
         let sourceGen = 'const' + this.getWSRegion(0) + this._bType
             + this.getWSRegion(1) + this._identifier
-            + this.getWSRegion(2) + '=' + this.getWSRegion(3);
-        if (this._bType === 'string') {
-            sourceGen += '"' + this._value + '"';
+
+        const expression = this.children[0];
+        if (expression) {
+            sourceGen += this.getWSRegion(2) + '=' + this.getWSRegion(3) + expression.getExpressionString();
         } else {
-            sourceGen += this._value;
+            sourceGen += this.getWSRegion(4);
         }
         return sourceGen;
     }
@@ -82,7 +83,6 @@ class ConstantDefinition extends VariableDeclaration {
         }
         this.setBType(jsonNode.constant_definition_btype, { doSilently: true });
         this.setIdentifier(jsonNode.constant_definition_identifier, { doSilently: true });
-        this.setValue(jsonNode.constant_definition_value, { doSilently: true });
 
         for (const childNode of jsonNode.children) {
             const child = this.getFactory().createFromJson(childNode);


### PR DESCRIPTION
We cant visit the included variable def statement as a whole because that results in a recursive loop. (because variableDef is pointed to the parent constDef)
So visiting only the rhs. Identifier and the type are asigned to the json object seperately.
Fixes #2296