### PR TITLE
Fix the imports and globals decorator for firefox

### DIFF
--- a/modules/web/js/ballerina/components/global-definitions.jsx
+++ b/modules/web/js/ballerina/components/global-definitions.jsx
@@ -32,6 +32,7 @@ const GlobalDefinitions = ({ bBox, title, numberOfItems, onExpand }) => {
     const iconLeftPadding = variablesPaneDefaults.iconLeftPadding;
     const noOfGlobalsLeftPadding = variablesPaneDefaults.noOfGlobalsLeftPadding;
     const noOfGlobalsTextPadding = variablesPaneDefaults.noOfGlobalsTextPadding;
+    const globalDefDecorationWidth = variablesPaneDefaults.globalDefDecorationWidth;
     const globalsLabelWidth = SizingUtils.getOnlyTextWidth(title);
 
     const noOfGlobalsTextWidth = SizingUtils.getOnlyTextWidth(numberOfItems, { fontSize: globalsNoFontSize });
@@ -70,6 +71,7 @@ const GlobalDefinitions = ({ bBox, title, numberOfItems, onExpand }) => {
                 x={bBox.x}
                 y={bBox.y}
                 height={headerHeight}
+                width={globalDefDecorationWidth}
                 className="global-definition-decorator"
             />
             <text x={labelBbox.x} y={labelBbox.y} rx="0" ry="0">

--- a/modules/web/js/ballerina/components/global-item.jsx
+++ b/modules/web/js/ballerina/components/global-item.jsx
@@ -118,13 +118,6 @@ export default class GlobalDefinitionItem extends React.Component {
                     {globalItemValue}
                 </text>
                 <rect
-                    x={x}
-                    y={y}
-                    height={h}
-                    width={w}
-                    className="global-definition-decorator"
-                />
-                <rect
                     x={x + w - 30}
                     y={y}
                     height={h}

--- a/modules/web/js/ballerina/components/globals-expanded.jsx
+++ b/modules/web/js/ballerina/components/globals-expanded.jsx
@@ -81,12 +81,13 @@ export default class GlobalExpanded extends React.Component {
     }
 
     render() {
-        const bBox = this.props.bBox;
+        const { bBox, globals } = this.props;
         const topBarHeight = variablesPaneDefaults.topBarHeight;
         const globalInputHeight = variablesPaneDefaults.inputHeight;
         const iconSize = variablesPaneDefaults.iconSize;
         const globalHeight = variablesPaneDefaults.globalItemHeight;
         const globalDeclarationWidth = variablesPaneDefaults.globalDeclarationWidth;
+        const globalDefDecorationWidth = variablesPaneDefaults.globalDefDecorationWidth;
         const leftPadding = 10;
         const globalElements = [];
         const editorOuterPadding = 10;
@@ -98,7 +99,7 @@ export default class GlobalExpanded extends React.Component {
 
         let lastGlobalElementY = topBarBbox.y + topBarHeight;
 
-        this.props.globals.forEach((globalDec) => {
+        globals.forEach((globalDec) => {
             const itemBBox = {
                 x: bBox.x,
                 y: lastGlobalElementY,
@@ -126,10 +127,11 @@ export default class GlobalExpanded extends React.Component {
             initialValue: '',
         };
 
+        const totalHeight = topBarHeight + (globals.length*globalHeight) + globalInputHeight;
+
         return (
             <g className="global-definitions-collection">
                 <rect x={topBarBbox.x} y={topBarBbox.y} height={topBarHeight} width={globalDeclarationWidth} style={{ fill: '#ddd' }} />
-                <rect x={topBarBbox.x} y={topBarBbox.y} height={topBarHeight} className="global-definition-decorator" />
                 <text x={topBarBbox.x + leftPadding} y={topBarBbox.y + topBarHeight / 2} className="global-definitions-topbar-label">
                     {this.props.title}</text>
                 <image
@@ -140,7 +142,6 @@ export default class GlobalExpanded extends React.Component {
                 {globalElements}
                 <rect x={bBox.x} y={lastGlobalElementY} height={globalInputHeight} width={globalDeclarationWidth} className="add-global-button-background"
                       />
-                <rect x={bBox.x} y={lastGlobalElementY} height={globalInputHeight} width={globalDeclarationWidth} className="global-definition-decorator" />
                 <g onClick={e => {this.openEditor(textBoxBBox)}}>
                     <rect
                         x={bBox.x + 7} y={lastGlobalElementY + 7} height={globalInputHeight - 14} width={globalDeclarationWidth - 14}
@@ -148,6 +149,7 @@ export default class GlobalExpanded extends React.Component {
                     />
                     <text x={bBox.x + 14} y={lastGlobalElementY + globalInputHeight / 2} className="add-global-button-text" >{this.props.addText}</text>
                 </g>
+                <rect x={topBarBbox.x} y={topBarBbox.y} height={totalHeight} width={globalDefDecorationWidth} className="global-definition-decorator" />
             </g>
         );
     }

--- a/modules/web/js/ballerina/components/import-declaration-expanded.jsx
+++ b/modules/web/js/ballerina/components/import-declaration-expanded.jsx
@@ -47,7 +47,7 @@ export default class importDeclarationExpanded extends React.Component {
     }
 
     render() {
-        const bBox = this.props.bBox;
+        const { bBox, imports } = this.props;
         const importDeclarationHeight = 30;
         const importInputHeight = 40;
         const importDeclarationWidth = 310;
@@ -56,6 +56,7 @@ export default class importDeclarationExpanded extends React.Component {
         const topBarHeight = 25;
         const iconSize = 20;
         const importElements = [];
+        const importDecDecoratorWidth = 3;
 
         const topBarBbox = {
             x: bBox.x,
@@ -64,7 +65,7 @@ export default class importDeclarationExpanded extends React.Component {
 
         let lastImportElementY = topBarBbox.y + topBarHeight;
 
-        this.props.imports.forEach((importDec, count) => {
+        imports.forEach((importDec, count) => {
             const itemBBox = {
                 x: bBox.x,
                 y: lastImportElementY,
@@ -94,10 +95,11 @@ export default class importDeclarationExpanded extends React.Component {
             initialValue: '',
         };
 
+        const totalHeight = topBarHeight + (imports.length*importDeclarationHeight) + importInputHeight
+
         return (
             <g className="import-declarations-collection">
                 <rect x={topBarBbox.x} y={topBarBbox.y} height={topBarHeight} width={importDeclarationWidth} style={{ fill: '#ddd' }} />
-                <rect x={topBarBbox.x} y={topBarBbox.y} height={topBarHeight} className="import-definition-decorator" />
                 <text x={topBarBbox.x + leftPadding} y={topBarBbox.y + topBarHeight / 2} className="import-declaration-topbar-label">Imports</text>
                 <image
                     width={iconSize}
@@ -120,7 +122,6 @@ export default class importDeclarationExpanded extends React.Component {
                     />
                     <text x={bBox.x + 14} y={lastImportElementY + importInputHeight / 2} className="add-import-button-text" >{'+ Add Import'}</text>
                 </g>
-                <rect x={bBox.x} y={lastImportElementY} height={importInputHeight} className="import-definition-decorator" />
                 <SuggestionsText
                     x={bBox.x + 5}
                     y={lastImportElementY + 5}
@@ -132,6 +133,7 @@ export default class importDeclarationExpanded extends React.Component {
                     onEnter={this.props.onAddImport}
                     onSuggestionSelected={this.onImportSelect}
                 />
+                <rect x={topBarBbox.x} y={topBarBbox.y} height={totalHeight} width={importDecDecoratorWidth} className="import-definition-decorator" />
             </g>
         );
     }

--- a/modules/web/js/ballerina/components/import-declaration-item.jsx
+++ b/modules/web/js/ballerina/components/import-declaration-item.jsx
@@ -64,7 +64,6 @@ export default class importDeclarationItem extends React.Component {
                 <text x={x + leftPadding} y={y + h / 2} rx="0" ry="0" className="import-definition-text">
                     {this.props.importDec.getPackageName()}
                 </text>
-                <rect x={x} y={y} height={h} className="import-definition-decorator" />
                 <rect x={x + w - 30} y={y} height={h} width={30} className="delete-background" onClick={this.handleDeleteClick} />
                 <text x={x + w - 18} y={y + h / 2} style={deleteStyle} className="delete-x" onClick={this.handleDeleteClick}>x</text>
             </g>

--- a/modules/web/js/ballerina/components/import-declaration.jsx
+++ b/modules/web/js/ballerina/components/import-declaration.jsx
@@ -34,6 +34,7 @@ const ImportDeclaration = ({ bBox, viewState, noOfImports, onClick }) => {
         importLabelWidth = 48,
         noOfImportsTextWidth = 100,
         badgeWidth = 150,
+        importDecDecoratorWidth = 3,
     } = viewState;
 
     const labelBbox = {
@@ -62,7 +63,13 @@ const ImportDeclaration = ({ bBox, viewState, noOfImports, onClick }) => {
                 ry="0"
                 className="package-definition-header"
             />
-            <rect x={bBox.x} y={bBox.y} height={headerHeight} className="import-definition-decorator" />
+            <rect
+                x={bBox.x}
+                y={bBox.y}
+                height={headerHeight}
+                width={importDecDecoratorWidth}
+                className="import-definition-decorator"
+            />
             <text x={labelBbox.x} y={labelBbox.y} rx="0" ry="0">
                 Imports
             </text>

--- a/modules/web/js/ballerina/configs/designer-defaults.js
+++ b/modules/web/js/ballerina/configs/designer-defaults.js
@@ -295,4 +295,5 @@ export const variablesPane = {
     noOfGlobalsLeftPadding: 12,
     noOfGlobalsTextPadding: 10,
     globalDeclarationWidth: 310,
+    globalDefDecorationWidth: 3,
 };

--- a/modules/web/js/ballerina/visitors/dimension-calculator/package-definition-dimension-calculator-visitor.js
+++ b/modules/web/js/ballerina/visitors/dimension-calculator/package-definition-dimension-calculator-visitor.js
@@ -71,6 +71,7 @@ class PackageDefinitionDimensionCalculatorVisitor {
         const noOfImportsBGHeight = 18;
         const importLabelWidth = 48.37;
         const noOfImportsTextPadding = 10;
+        const importDecDecoratorWidth = 3;
 
         const imports = node.children.filter(c => c.constructor.name === 'ImportDeclaration');
         const noOfImports = imports.length;
@@ -94,6 +95,7 @@ class PackageDefinitionDimensionCalculatorVisitor {
             noOfImportsTextWidth,
             noOfImportsBGWidth,
             badgeWidth,
+            importDecDecoratorWidth,
         };
     }
 

--- a/modules/web/scss/modules/diagram.scss
+++ b/modules/web/scss/modules/diagram.scss
@@ -80,7 +80,6 @@
 }
 
 .import-definition-decorator {
-    width: 3px;
     fill: $brand-primary;
 }
 
@@ -93,7 +92,6 @@
 }
 
 .global-definition-decorator {
-    width: 3px;
     fill: #9b59b6;
 }
 


### PR DESCRIPTION
The width of svg elements cannot be set by css by specification. It works in chrome but not in firefox.

Fixes #2397 