### PR TITLE
Remove string literal re-escaping of WS chars

### DIFF
--- a/modules/web/js/ballerina/ast/expressions/basic-literal-expression.js
+++ b/modules/web/js/ballerina/ast/expressions/basic-literal-expression.js
@@ -64,7 +64,7 @@ class BasicLiteralExpression extends Expression {
     getExpressionString() {
         if (this._basicLiteralType === 'string') {
             // Adding double quotes if it is a string.
-            return '\"' + this.escapeEscapeChars(this._basicLiteralValue) + '\"' + this.getWSRegion(1);
+            return '"' + this._basicLiteralValue + '"' + this.getWSRegion(1);
         }
         return this._basicLiteralValue + this.getWSRegion(1);
     }
@@ -75,13 +75,6 @@ class BasicLiteralExpression extends Expression {
 
     getBasicLiteralType() {
         return this._basicLiteralType;
-    }
-
-    escapeEscapeChars(stringVal) {
-        return stringVal.replace(/"/g, '\\"')
-                        .replace(/\n/g, '\\n')
-                        .replace(/\r/g, '\\r')
-                        .replace(/\t/g, '\\t');
     }
 }
 


### PR DESCRIPTION
The root cause for which this code was needed
is fixed by a fix which is pushed to core. Now,
in verbose mode, while building the model, core
will not un-escapse string literals.

Core-PR https://github.com/ballerinalang/ballerina/pull/2959