### PR TITLE
Fixed split view shown for custom editors.

### DIFF
--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -646,7 +646,7 @@
 
     .bottom-right-controls-container {
         position: absolute;
-        bottom: 23px;
+        bottom: 50px;
         right: 50px;
         z-index: 30;
         background: $bottom-right-controls-bgcolor;

--- a/modules/web/src/core/editor/views/EditorTabs.jsx
+++ b/modules/web/src/core/editor/views/EditorTabs.jsx
@@ -100,8 +100,9 @@ class EditorTabs extends View {
      */
     getPreviewViewSize(previewViewEnabled) {
         const { history } = this.props.editorPlugin.appContext.pref;
+        const activeEditor = this.props.editorPlugin.appContext.editor.getActiveEditor();
         let previewViewSize;
-        if (previewViewEnabled) {
+        if (previewViewEnabled && !(activeEditor instanceof CustomEditor)) {
             if (history.get(HISTORY.PREVIEW_VIEW_ENABLED_SIZE)) {
                 previewViewSize = parseInt(history.get(HISTORY.PREVIEW_VIEW_ENABLED_SIZE), 10);
             } else {

--- a/modules/web/src/core/editor/views/EditorTabs.jsx
+++ b/modules/web/src/core/editor/views/EditorTabs.jsx
@@ -30,7 +30,7 @@ import Editor from './../model/Editor';
 import CustomEditor from './../model/CustomEditor';
 import EditorTabTitle from './EditorTabTitle';
 
-const DEFAULT_PREVIEW_VIEW_SIZE = 500;
+const DEFAULT_PREVIEW_VIEW_SIZE = document.body.clientWidth - (((document.body.clientWidth / 2) - 250));
 const MINIMUM_PREVIEW_VIEW_SIZE = 250;
 
 const tabTitleHeight = 21;

--- a/modules/web/src/core/layout/handlers.js
+++ b/modules/web/src/core/layout/handlers.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import log from 'log';
 import { COMMANDS, EVENTS, REGIONS } from './constants';
 import { COMMANDS as EDITOR_COMMANDS } from './../editor/constants';
-import { withReRenderSupport } from './components/utils';
+import { withViewFeatures } from './components/utils';
 
 /**
  * Provides command handler definitions of layout manager plugin.
@@ -30,7 +30,7 @@ export function getHandlerDefinitions(layoutManager) {
                                 title: tabTitle,
                                 icon: tabIcon,
                                 customTitleClass,
-                                component: withReRenderSupport(component, pluginID),
+                                component: withViewFeatures(component, pluginID),
                                 propsProvider,
                             });
                         }


### PR DESCRIPTION
Fixes https://github.com/ballerinalang/composer/issues/3123 , https://github.com/ballerinalang/composer/issues/3118

Fixes the following scenario as well:
"while split view active, close all opened tabs, refresh, this will trigger welcome page to opened. Welcome page will fill only half the page
for custom tabs, we need to avoid setting width calculated from split view history data" @kaviththiranga 
