### PR TITLE
Set transform statement box icon size inline

### DIFF
--- a/modules/web/js/ballerina/diagram/views/default/components/transform/transform-statement.css
+++ b/modules/web/js/ballerina/diagram/views/default/components/transform/transform-statement.css
@@ -257,8 +257,6 @@ svg.plumbConnect path {
 }
 
 .transform-action-button {
-    width: 28px;
-    height: 30px;
     fill: #666769;
 }
 

--- a/modules/web/js/ballerina/diagram2/views/default/components/decorators/lifeline.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/decorators/lifeline.jsx
@@ -69,7 +69,6 @@ class LifeLine extends React.Component {
         }*/
     }
     render() {
-        console.log(this.props.bBox);
         const bBox = this.props.bBox;
         const iconSize = 13;
         const lineClass = `${this.props.classes.lineClass} unhoverable`;

--- a/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-statement-decorator.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-statement-decorator.jsx
@@ -196,7 +196,6 @@ class TransformStatementDecorator extends React.Component {
 
         const actionBbox = new SimpleBBox();
         const fill = this.state.innerDropZoneExist ? {} : { fill: 'none' };
-        const iconSize = 14;
         actionBbox.w = DesignerDefaults.actionBox.width;
         actionBbox.h = DesignerDefaults.actionBox.height;
         actionBbox.x = bBox.x + (bBox.w - actionBbox.w) / 2;
@@ -236,13 +235,13 @@ class TransformStatementDecorator extends React.Component {
                     <g className="transform-button" onClick={e => this.onExpand()}>
                         <rect x={expand_button_x - 8}
                               y={expand_button_y - 8}
-                              width={iconSize}
-                              height={iconSize}
+                              width={28}
+                              height={30}
                               className="transform-action-button"/>
                         <image className="transform-action-icon"
                                x={expand_button_x} y={expand_button_y}
-                               width={iconSize}
-                               height={iconSize}
+                               width={14}
+                               height={14}
                                xlinkHref={ImageUtil.getSVGIconString('expand')}>
                             <title>Expand</title>
                         </image>


### PR DESCRIPTION
Setting it from css only works on chrome. Firefox follows the spec so its not possible to set height and width of svg elements from css.