### PR TITLE
Fixed editor area being larger than the document size

### DIFF
--- a/modules/web/scss/modules/layout.scss
+++ b/modules/web/scss/modules/layout.scss
@@ -69,7 +69,7 @@
   }
 
   &.disabled {
-    cursor: not-allowed;
+    cursor: auto;
     :hover {
       border-color: transparent;
     }

--- a/modules/web/src/core/editor/views/EditorTabs.jsx
+++ b/modules/web/src/core/editor/views/EditorTabs.jsx
@@ -311,6 +311,7 @@ class EditorTabs extends View {
             <SplitPane
                 ref={(ref) => { this.previewSplitRef = ref; }}
                 split="vertical"
+                allowResize={this.state.previewViewEnabled}
                 minSize={this.state.previewViewEnabled ? MINIMUM_PREVIEW_VIEW_SIZE : 0}
                 defaultSize={this.getPreviewViewSize(this.state.previewViewEnabled)}
                 onDragFinished={(previewViewSize) => {

--- a/modules/web/src/core/layout/components/App.jsx
+++ b/modules/web/src/core/layout/components/App.jsx
@@ -12,6 +12,7 @@ import { withReRenderEnabled } from './utils';
 
 const leftPanelDefaultSize = 300;
 const leftPanelMaxSize = 700;
+const leftPanelClosedSize = 42;
 const bottomPanelDefaultSize = 300;
 const bottomPanelMaxSize = 700;
 const headerHeight = 24;
@@ -156,9 +157,10 @@ class App extends React.Component {
                     ref={(ref) => { this.leftRightSplitPane = ref; }}
                     split="vertical"
                     className="left-right-split-pane"
-                    minSize={this.state.showLeftPanel ? leftPanelDefaultSize : 0}
+                    allowResize={this.state.showLeftPanel}
+                    minSize={this.state.showLeftPanel ? leftPanelDefaultSize : leftPanelClosedSize}
                     maxSize={leftPanelMaxSize}
-                    defaultSize={this.state.showLeftPanel ? this.state.leftPanelSize : 0}
+                    defaultSize={this.state.showLeftPanel ? this.state.leftPanelSize : leftPanelClosedSize}
                     onDragFinished={(size) => {
                         this.setLeftPanelState(true, size);
                         if (!_.isNil(this.leftRightSplitPane)) {
@@ -168,9 +170,6 @@ class App extends React.Component {
                             });
                         }
                     }
-                    }
-                    pane2Style={
-                        this.state.showLeftPanel ? {} : { position: 'relative', left: '42px' }
                     }
                     style={{
                         height: this.state.documentHeight - (headerHeight + toolAreaHeight),


### PR DESCRIPTION
Also disallow dragging split view in when its not active