### PR TITLE
Made lang server client call all pending callbacks on websocket close

### DIFF
--- a/modules/web/js/ballerina/env/environment.js
+++ b/modules/web/js/ballerina/env/environment.js
@@ -61,6 +61,11 @@ class BallerinaEnvironment extends EventChannel {
                 getLangServerClientInstance()
                     .then((langServerClient) => {
                         langServerClient.workspaceSymbolRequest('builtinTypes', (data) => {
+                            if(!data){
+                                reject();
+                                return;
+                            }
+
                             this.initializeBuiltinTypes(data.result);
                             Promise.all([
                                 this.initializePackages(),

--- a/modules/web/js/ballerina/model/tree-util.js
+++ b/modules/web/js/ballerina/model/tree-util.js
@@ -373,6 +373,10 @@ class TreeUtil extends AbstractTreeUtil {
                 return client.getCompletions(options);
             })
             .then((response) => {
+                if (!response) {
+                    return Array(numberOfVars).fill().map((el, index) => (`${varPrefix}${index + 1}`));
+                }
+
                 const varNameRegex = new RegExp(varPrefix + '[\\d]*');
                 const completions = response.result.filter((completionItem) => {
                     // all variables have type as 9 as per the declaration in lang server

--- a/modules/web/js/langserver/lang-server-client-controller.js
+++ b/modules/web/js/langserver/lang-server-client-controller.js
@@ -63,6 +63,12 @@ class LangServerClientController extends EventChannel {
                 instance = undefined;
                 reject(error);
             });
+            this.langserverChannel.on('close', () => {
+                // call all pending requests
+                this.requestSessions.forEach(session => {
+                    session.executeCallback();
+                })
+            });
         });
     }
 

--- a/modules/web/js/langserver/langserver-channel.js
+++ b/modules/web/js/langserver/langserver-channel.js
@@ -64,9 +64,10 @@ class LangserverChannel extends EventChannel {
         if (this.wsCloseEventHandler) {
             this.wsCloseEventHandler(event);
         } else {
-            // invoke default ws close event handler. 
+            // invoke default ws close event handler.
             this.defaultWsCloseEventHandler(event);
         }
+        this.trigger('close');
     }
 
     onError(error) {


### PR DESCRIPTION
The getNewTempVar function returns an array of vars even when langserver fails. (They are not unique names though)