### PR TITLE
Fix regression issues in Transformer layout

### DIFF
--- a/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-expanded.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-expanded.jsx
@@ -1098,6 +1098,7 @@ class TransformExpanded extends React.Component {
     }
 
     render() {
+        const { leftOffset, width, height } = this.props;
         const vertices = this.state.vertices.filter(vertex => (!vertex.isInner));
         const inputNodes = this.props.model.inputs;
         const outputNodes = this.props.model.outputs;
@@ -1154,6 +1155,7 @@ class TransformExpanded extends React.Component {
         return (
             <div
                 className='transformOverlay'
+                style={{ paddingLeft: leftOffset }}
             >
                 <div id='transformHeader' className='transform-header'>
                     <i onClick={this.onClose} className='fw fw-left icon close-transform' />
@@ -1291,6 +1293,9 @@ class TransformExpanded extends React.Component {
 TransformExpanded.propTypes = {
     model: PropTypes.instanceOf(TransformNode).isRequired,
     panelResizeInProgress: PropTypes.bool.isRequired,
+    leftOffset: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
 };
 
 TransformExpanded.contextTypes = {

--- a/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-statement.css
+++ b/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-statement.css
@@ -194,14 +194,12 @@ svg.plumbConnect path {
 }
 
 .transformOverlay {
-    position: absolute;;
-    padding-left: 244px;
+    position: absolute;
     background-color: #fefefe;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
-    min-width: 1000px;
 }
 
 /* The Close Button */

--- a/modules/web/js/ballerina/views/design-view.jsx
+++ b/modules/web/js/ballerina/views/design-view.jsx
@@ -133,15 +133,16 @@ class DesignView extends React.Component {
         return (
             <div className="design-view-container" style={{ display: this.props.show ? 'block' : 'none'}}>
                 <div className="outerCanvasDiv">
+                    <DragLayer />
                     <Scrollbars
                         style={{
                             width: this.props.width - TOOL_PALETTE_WIDTH,
                             height: this.props.height,
+                            marginLeft: TOOL_PALETTE_WIDTH,
                         }}
                         autoHide // Hide delay in ms
                         autoHideTimeout={1000}
                     >
-                        <DragLayer />
                         <div className="canvas-container">
                             <div className="canvas-top-controls-container" />
                             <div className="html-overlay" ref={this.setOverlayContainer} />
@@ -156,13 +157,16 @@ class DesignView extends React.Component {
                                 }
                             </div>
                         </div>
-                        {isTransformActive &&
-                            <TransformExpanded
-                                model={activeTransformModel}
-                                panelResizeInProgress={this.props.panelResizeInProgress}
-                            />
-                        }
                     </Scrollbars>
+                    {isTransformActive &&
+                        <TransformExpanded
+                            model={activeTransformModel}
+                            panelResizeInProgress={this.props.panelResizeInProgress}
+                            leftOffset={TOOL_PALETTE_WIDTH}
+                            width={this.props.width - TOOL_PALETTE_WIDTH}
+                            height={this.props.height}
+                        />
+                    }
                 </div>
                 <div className="tool-palette-container" ref={this.setToolPaletteContainer}>
                     <ToolPaletteView

--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -2730,7 +2730,6 @@
     }
     
     .design-view-container {
-        padding-left: 244px;
         padding-top: 0;
         height: 100%;
     }


### PR DESCRIPTION
Seperate transform extended layout from scrolling container.
Refactor hardcoded offsets in styles (for tool pallete).
Forward width/height details to transform overly.