### PR TITLE
Use brackets around default expression for unary + and -

### DIFF
--- a/modules/web/js/ballerina/tool-palette/item-provider/operator-tools.js
+++ b/modules/web/js/ballerina/tool-palette/item-provider/operator-tools.js
@@ -193,7 +193,7 @@ const plusOpTool = {
     icon: 'add',
     title: 'Plus',
     factoryArgs: {
-        defaultExpression: '+ 1',
+        defaultExpression: '+ (1)',
     },
     nodeFactoryMethod: operatorStatementCreator,
 };
@@ -204,7 +204,7 @@ const minusOpTool = {
     icon: 'minus',
     title: 'Minus',
     factoryArgs: {
-        defaultExpression: '- 1',
+        defaultExpression: '- (1)',
     },
     nodeFactoryMethod: operatorStatementCreator,
 };


### PR DESCRIPTION
This creates a binary expression instead of a literal.
Fixes #3669 