### PR TITLE
Add defined Structs into type selection drop down

### DIFF
--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
@@ -238,10 +238,7 @@ class StructNode extends React.Component {
         };
         const { environment } = this.context;
         // Environment does not load the types
-        // const structSuggestions = environment.getTypes().map(name => ({ name }));
-        const typeArray = ['any', 'blob', 'boolean', 'connector', 'datatable', 'float', 'int', 'json', 'map',
-            'message', 'string', 'type', 'xml'];
-        const structSuggestions = typeArray.map(name => ({ name }));
+        const structSuggestions = environment.getTypes().map(name => ({ name }));
         return (
             <g>
                 <rect x={x} y={y} width={w} height={h} className="struct-content-operations-wrapper" fill="#3d3d3d" />


### PR DESCRIPTION
We can see defined "Struct1" and "Person" in the drop down list.

<img width="710" alt="screen shot 2017-10-17 at 3 17 14 am" src="https://user-images.githubusercontent.com/6814264/31636834-bdac29aa-b2e9-11e7-8be2-3877b0f32550.png">
