### PR TITLE
Prevent adding empty rows when adding variables.

### DIFF
--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/connector-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/connector-node.jsx
@@ -83,6 +83,9 @@ class ConnectorNode extends React.Component {
      * @memberof ServiceNode
      */
     handleAddVariable(value) {
+        if (!value) {
+            return;
+        }
         const fragment = FragmentUtils.createStatementFragment(`${value};`);
         const parsedJson = FragmentUtils.parseFragment(fragment);
         const index = this.props.model.getVariableDefs().length - 1;

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/service-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/service-node.jsx
@@ -86,6 +86,9 @@ class ServiceNode extends React.Component {
      * @memberof ServiceNode
      */
     handleAddVariable(value) {
+        if (!value) {
+            return;
+        }
         const fragment = FragmentUtils.createStatementFragment(`${value};`);
         const parsedJson = FragmentUtils.parseFragment(fragment);
         const index = this.props.model.getVariables().length - 1;


### PR DESCRIPTION
Only globals were validated using empty string check.
Added them for connector and service variales too.

Fixing issue
https://github.com/ballerinalang/composer/issues/3875