### PR TITLE
Fixes to custom tabs (improve doc tabs)

### DIFF
--- a/modules/web/js/ballerina/views/ballerina-file-editor.jsx
+++ b/modules/web/js/ballerina/views/ballerina-file-editor.jsx
@@ -459,7 +459,15 @@ class BallerinaFileEditor extends React.Component {
      */
     openDocumentation(packageName, symbolName) {
         this.props.commandProxy.dispatch(LAYOUT_COMMANDS.SHOW_VIEW,
-            { id: DOC_VIEW_ID, additionalProps: { packageName, symbolName } } );
+            { id: DOC_VIEW_ID,
+                additionalProps: {
+                    packageName, symbolName,
+                },
+                options: {
+                    clone: true,
+                    key: `${DOC_VIEW_ID}&${packageName}&${symbolName}`,
+                },
+            });
     }
 
     /**

--- a/modules/web/src/core/editor/plugin.js
+++ b/modules/web/src/core/editor/plugin.js
@@ -248,10 +248,12 @@ class EditorPlugin extends Plugin {
      * @param {Object} command args
      */
     onOpenCustomEditorTab(args) {
-        const { id, title, icon, component, propsProvider, additionalProps, customTitleClass, activate } = args;
-        const existingEditor = this.getEditorByID(id);
+        const { id, title, icon, component, propsProvider, options,
+            additionalProps, customTitleClass, activate } = args;
+        const derivedId = options && options.clone ? options.key : id;
+        const existingEditor = this.getEditorByID(derivedId);
         if (!existingEditor) {
-            const editor = new CustomEditor(id, title, icon, component, propsProvider,
+            const editor = new CustomEditor(derivedId, title, icon, component, propsProvider,
                 additionalProps, customTitleClass);
             this.openedEditors.push(editor);
             if (activate || _.isNil(this.activeEditorID)) {

--- a/modules/web/src/core/editor/views/EditorTabs.jsx
+++ b/modules/web/src/core/editor/views/EditorTabs.jsx
@@ -168,6 +168,13 @@ class EditorTabs extends View {
                 width: this.props.width, // custom tabs doesn't support split view hence full width
                 height: this.props.height - tabTitleHeight,
             };
+            const finalProps = {
+                ...propsProvider(),
+                ...additionalProps,
+                ...customTabDimensions,
+                isActive: activeEditorID === id,
+                panelResizeInProgress: this.props.panelResizeInProgress || this.state.panelResizeInProgress,
+            };
             return (
                 <TabPane
                     tab={
@@ -184,7 +191,7 @@ class EditorTabs extends View {
                                 ×
                             </button>
                             <i className={`fw fw-${icon} tab-icon`} />
-                            {title}
+                            {_.isFunction(title) ? title(finalProps) : title}
                         </div>
                     }
                     data-extra="tabpane"
@@ -196,11 +203,7 @@ class EditorTabs extends View {
                         autoHideTimeout={1000}
                     >
                         <editor.component
-                            isActive={activeEditorID === id}
-                            {...propsProvider()}
-                            {...additionalProps}
-                            {...customTabDimensions}
-                            panelResizeInProgress={this.props.panelResizeInProgress || this.state.panelResizeInProgress}
+                            {...finalProps}
                         />
                     </Scrollbars>
                 </TabPane>

--- a/modules/web/src/core/layout/commands.js
+++ b/modules/web/src/core/layout/commands.js
@@ -14,6 +14,7 @@ export function getCommandDefinitions() {
             argTypes: {
                 id: PropTypes.string.isRequired,
                 additionalProps: PropTypes.objectOf(Object),
+                options: PropTypes.objectOf(Object),
             },
         },
         {

--- a/modules/web/src/core/layout/handlers.js
+++ b/modules/web/src/core/layout/handlers.js
@@ -16,7 +16,7 @@ export function getHandlerDefinitions(layoutManager) {
     return [
         {
             cmdID: COMMANDS.SHOW_VIEW,
-            handler: ({ id, additionalProps }) => {
+            handler: ({ id, additionalProps, options }) => {
                 const view = _.find(layoutManager.views, ['id', id]);
                 if (!_.isNil(view)) {
                     const { region, component, propsProvider, pluginID,
@@ -33,6 +33,7 @@ export function getHandlerDefinitions(layoutManager) {
                                 propsProvider,
                                 additionalProps,
                                 activate: true,
+                                options,
                             });
                             break;
                         }

--- a/modules/web/src/plugins/ballerina/plugin.js
+++ b/modules/web/src/plugins/ballerina/plugin.js
@@ -115,7 +115,8 @@ class BallerinaPlugin extends Plugin {
                     },
                     region: REGIONS.EDITOR_TABS,
                     regionOptions: {
-                        tabTitle: 'docs',
+                        tabTitle: ({ packageName }) => `${packageName} docs`,
+                        customTitleClass: CLASSES.TAB_TITLE.DESIGN_VIEW,
                     },
                     displayOnLoad: false,
                 },


### PR DESCRIPTION
+ support clones
+ support custom title providers

Doc tabs will now open new tab per each package. Tab title reflects package name.