### PR TITLE
Updated react version to 15.6.2

### DIFF
--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -92,7 +92,7 @@
     "prop-types": "^15.5.8",
     "rc-menu": "^5.0.10",
     "rc-tabs": "^9.1.3",
-    "react": "^15.4.2",
+    "react": "^15.6.2",
     "react-ace": "^5.2.0",
     "react-autosuggest": "^9.0.1",
     "react-bootstrap": "^0.31.1",


### PR DESCRIPTION
React 15.6.2 is MIT license.
https://reactjs.org/blog/2017/09/26/react-v16.0.html