### PR TITLE
Struct generation by importing JSON

### DIFF
--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-definition-item.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-definition-item.jsx
@@ -108,11 +108,16 @@ class StructDefinitionItem extends React.Component {
             height: DesignerDefaults.structDefinitionStatement.height,
         };
 
+        let zebraShadeType = '-light';
+        if (this.props.index % 2 === 1) {
+            zebraShadeType = '-dark';
+        }
+
         return (
             <g key={identifier} className="struct-definition-statement">
 
                 <g className="struct-variable-definition-type" >
-                    <rect {...typeCellbox} className="struct-added-value-wrapper" />
+                    <rect {...typeCellbox} className={'struct-added-value-wrapper' + zebraShadeType} />
                     <text
                         x={DesignerDefaults.structDefinition.panelPadding + x}
                         y={y + (DesignerDefaults.structDefinitionStatement.height / 2) + 3}
@@ -123,7 +128,7 @@ class StructDefinitionItem extends React.Component {
                     className="struct-variable-definition-identifier"
                     onClick={() => this.setState({ newIdentifierEditing: true })}
                 >
-                    <rect {...identifierCellBox} className="struct-added-value-wrapper" />
+                    <rect {...identifierCellBox} className={'struct-added-value-wrapper' + zebraShadeType} />
                     <text
                         x={x + DesignerDefaults.structDefinition.panelPadding + columnSize}
                         y={y + DesignerDefaults.structDefinitionStatement.height / 2 + 3}
@@ -169,7 +174,7 @@ class StructDefinitionItem extends React.Component {
                     className="struct-variable-definition-value"
                     onClick={() => this.setState({ newDefaultValueEditing: true })}
                 >
-                    <rect {...defaultValueBox} className="struct-added-value-wrapper" />
+                    <rect {...defaultValueBox} className={'struct-added-value-wrapper' + zebraShadeType} />
                     <text
                         x={x + DesignerDefaults.structDefinition.panelPadding + columnSize * 2}
                         y={y + DesignerDefaults.structDefinitionStatement.height / 2 + 3}
@@ -214,7 +219,7 @@ class StructDefinitionItem extends React.Component {
                     onClick={() => this.deleteStatement(model)}
                     width="30"
                     height="30"
-                    className="struct-delete-icon-wrapper"
+                    className={'struct-delete-icon-wrapper' + zebraShadeType}
                 />
                 <image
                     x={x + DesignerDefaults.structDefinitionStatement.width - DesignerDefaults.structDefinitionStatement.deleteButtonOffset + 9}

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-definition.css
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-definition.css
@@ -49,3 +49,8 @@ struct-variable-definition-value-text*/
     fill: #ffffff;
     cursor: pointer;
 }
+
+.ace_tooltip {
+    transform: translate(0px, -75px);
+    left: 10px !important;
+}

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-definition.css
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-definition.css
@@ -30,5 +30,22 @@ struct-variable-definition-value-text*/
     cursor: pointer;
 }
 
+.struct-import-json-button {
+    fill: #666769;
+    stroke-width: 0.5;
+    stroke: #dfdfdf;
+    shape-rendering: crispEdges;
+    cursor: pointer;
+}
 
+.struct-import-json-text {
+    dominant-baseline: middle;
+    fill: #c4c5c6;
+    cursor: pointer;
+}
 
+.struct-import-json-text:hover {
+    dominant-baseline: middle;
+    fill: #ffffff;
+    cursor: pointer;
+}

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
@@ -407,7 +407,7 @@ class StructNode extends React.Component {
                     y={y + 10}
                     width={25}
                     height={25}
-                    className="struct-added-value-wrapper"
+                    className="struct-added-value-wrapper-light"
                 />
                 <image
                     x={x + DesignerDefaults.structDefinitionStatement.width - 30 + submitButtonPadding}
@@ -474,6 +474,7 @@ class StructNode extends React.Component {
                                         validateIdentifierName={this.validateIdentifierName}
                                         validateDefaultValue={this.validateDefaultValue}
                                         addQuotesToString={this.addQuotesToString}
+                                        index={i}
                                     />
                                 );
                             }

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
@@ -214,6 +214,8 @@ class StructNode extends React.Component {
                     currentType = 'int';
                 } else if (this.isFloat(currentValue)) {
                     currentType = 'float';
+                } else if (currentValue === 'true' || currentValue === 'false') {
+                    currentType = 'boolean';
                 }
                 refExpr = TreeBuilder.build(FragmentUtils.parseFragment(
                   FragmentUtils.createStatementFragment(currentType + ' ' + currentName + ' = ' + currentValue + ';')));

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
@@ -230,10 +230,20 @@ class StructNode extends React.Component {
         });
     }
 
+    /**
+     * Check given value is an Integer
+     * @param  {Number} val value to check
+     * @return {Boolean}  is Intger
+     */
     isInt(val) {
         return !isNaN(val) && Number(val).toString().length === (Number.parseInt(Number(val), 10).toString().length);
     }
 
+    /**
+     * Check given value is an Integer
+     * @param  {Number} val value to check
+     * @return {Boolean}  is Intger
+     */
     isFloat(val) {
         return !isNaN(val) && !this.isInt(Number(val)) && val.toString().length > 0;
     }

--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/struct-node.jsx
@@ -187,11 +187,12 @@ class StructNode extends React.Component {
         this.setState({ canShowAddType: false });
     }
 
+    /**
+     * Open JSON import dialog box and pass callback
+     */
     onClickJsonImport() {
         const onImport = (json) => {
-            let fragment = FragmentUtils.createExpressionFragment(json);
-            let parsedJson = FragmentUtils.parseFragment(fragment);
-            let refExpr = TreeBuilder.build(parsedJson);
+            let refExpr = TreeBuilder.build(FragmentUtils.parseFragment(FragmentUtils.createExpressionFragment(json)));
             let currentValue;
             this.props.model.setFields([], true);
             refExpr.variable.initialExpression.keyValuePairs.forEach((ketValPair) => {
@@ -214,10 +215,8 @@ class StructNode extends React.Component {
                 } else if (this.isFloat(currentValue)) {
                     currentType = 'float';
                 }
-                fragment = FragmentUtils.createStatementFragment(currentType + ' ' + currentName
-                                                                  + ' = ' + currentValue + ';');
-                parsedJson = FragmentUtils.parseFragment(fragment);
-                refExpr = TreeBuilder.build(parsedJson);
+                refExpr = TreeBuilder.build(FragmentUtils.parseFragment(
+                  FragmentUtils.createStatementFragment(currentType + ' ' + currentName + ' = ' + currentValue + ';')));
                 this.props.model.addFields(refExpr.getVariable());
             });
         };

--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -930,10 +930,17 @@
         fill:#333;
     }
     
-    .struct-added-value-wrapper {
-        fill: #f3f3f3;
+    .struct-added-value-wrapper-light {
+            fill: #f3f3f3;
+            stroke-width: 0.5;
+            stroke: #dfdfdf;
+            shape-rendering: crispEdges;
+        }
+
+    .struct-added-value-wrapper-dark {
+        fill: #dcdcdc;
         stroke-width: 0.5;
-        stroke: #dfdfdf;
+        stroke: #cccccc;
         shape-rendering: crispEdges;
     }
     
@@ -943,8 +950,14 @@
         padding: 13px;
     }
     
-    .struct-delete-icon-wrapper {
+    .struct-delete-icon-wrapper-light {
         fill: #f3f3f3;
+        shape-rendering: crispEdges;
+        padding: 13px;
+    }
+
+    .struct-delete-icon-wrapper-dark {
+        fill: #dcdcdc;
         shape-rendering: crispEdges;
         padding: 13px;
     }

--- a/modules/web/src/config.js
+++ b/modules/web/src/config.js
@@ -26,6 +26,7 @@ import WelcomeTabPlugin from './plugins/welcome-tab/plugin';
 import ImportSwaggerPlugin from './plugins/import-swagger/plugin';
 import { PLUGIN_ID as HELP_PLUGIN_ID } from './plugins/help/constants';
 import { WELCOME_TAB_PLUGIN_ID } from './plugins/welcome-tab/constants';
+import ImportStructPlugin from './plugins/import-struct/plugin';
 
 export default {
     app: {
@@ -36,6 +37,7 @@ export default {
             TryItPlugin,
             WelcomeTabPlugin,
             ImportSwaggerPlugin,
+            ImportStructPlugin,
         ],
     },
     // provide plugin specific configs - if any.

--- a/modules/web/src/plugins/import-struct/constants.js
+++ b/modules/web/src/plugins/import-struct/constants.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export const DIALOG = {
+    IMPORT_STRUCT: 'composer.dialog.import.struct',
+};
+
+export const PLUGIN_ID = 'import.struct';

--- a/modules/web/src/plugins/import-struct/dialogs/import-struct-dialog.jsx
+++ b/modules/web/src/plugins/import-struct/dialogs/import-struct-dialog.jsx
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import Dialog from 'core/view/Dialog';
+import AceEditor from 'react-ace';
+
+/**
+ * File Open Wizard Dialog
+ * @extends React.Component
+ */
+class ImportStructDialog extends React.Component {
+
+    /**
+     * @inheritdoc
+     */
+    constructor(props) {
+        super(props);
+        this.state = {
+            error: '',
+            json: '',
+            selectedNode: undefined,
+            showDialog: true,
+        };
+        this.onImportJson = this.onImportJson.bind(this);
+        this.onDialogHide = this.onDialogHide.bind(this);
+        this.textChange = this.textChange.bind(this);
+    }
+
+    /**
+     * Setting the default file path on the dialog if not set in history.
+     * @memberof ImportStructDialog
+     */
+    componentDidMount() {
+    }
+
+    /**
+     * Called when user clicks 'Import Struct' menu item.
+     */
+    onImportJson() {
+        this.props.onImport(this.state.json);
+        this.setState({
+            error: '',
+            json: '',
+            showDialog: false,
+        });
+    }
+
+    /**
+     * Called when user hides the dialog
+     */
+    onDialogHide() {
+        this.setState({
+            error: '',
+            showDialog: false,
+        });
+    }
+
+    /**
+     * Updates the state of the dialog modal.
+     * @param {any} { error, selectedNode, filePath }
+     * @memberof ImportStructDialog
+     */
+    updateState({ error, selectedNode, filePath }) {
+        this.setState({
+            error,
+            filePath,
+            selectedNode,
+        });
+    }
+
+    textChange(newValue) {
+        this.setState({ json: newValue });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    render() {
+        return (
+            <Dialog
+                show={this.state.showDialog}
+                title="Import JSON for Struct Definition"
+                actions={
+                    <Button
+                        bsStyle="primary"
+                        onClick={this.onImportJson}
+                    >
+                        Import
+                    </Button>
+                }
+                closeAction
+                onHide={this.onDialogHide}
+                error={this.state.error}
+            >
+
+                <AceEditor
+                    mode='json'
+                    theme='monokai'
+                    onChange={this.textChange}
+                    value={this.state.json}
+                    name='json'
+                    editorProps={{
+                        $blockScrolling: Infinity,
+                    }}
+                    setOptions={{
+                        showLineNumbers: false,
+                    }}
+                    maxLines={Infinity}
+                    minLines={10}
+                    width='auto'
+                    showPrintMargin={false}
+                />
+
+
+            </Dialog>
+        );
+    }
+}
+
+ImportStructDialog.propTypes = {
+    onImport: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default ImportStructDialog;

--- a/modules/web/src/plugins/import-struct/dialogs/import-struct-dialog.jsx
+++ b/modules/web/src/plugins/import-struct/dialogs/import-struct-dialog.jsx
@@ -78,24 +78,19 @@ class ImportStructDialog extends React.Component {
     }
 
     /**
-     * Updates the state of the dialog modal.
-     * @param {any} { error, selectedNode, filePath }
-     * @memberof ImportStructDialog
+     * [onValidate description]
+     * @param  {array} errors List of validation errors on the editor
      */
-    updateState({ error, selectedNode, filePath }) {
-        this.setState({
-            error,
-            filePath,
-            selectedNode,
-        });
+    onValidate(errors) {
+        this.setState({ isValid: errors.length === 0 });
     }
 
+    /**
+     * Called when user types on the editor.
+     * @param  {string} newValue changed text value
+     */
     textChange(newValue) {
         this.setState({ json: newValue });
-    }
-
-    onValidate(isValid) {
-        this.setState({ isValid: isValid.length === 0 });
     }
 
     /**

--- a/modules/web/src/plugins/import-struct/dialogs/import-struct-dialog.jsx
+++ b/modules/web/src/plugins/import-struct/dialogs/import-struct-dialog.jsx
@@ -42,6 +42,7 @@ class ImportStructDialog extends React.Component {
         this.onImportJson = this.onImportJson.bind(this);
         this.onDialogHide = this.onDialogHide.bind(this);
         this.textChange = this.textChange.bind(this);
+        this.onValidate = this.onValidate.bind(this);
     }
 
     /**
@@ -59,6 +60,7 @@ class ImportStructDialog extends React.Component {
         this.setState({
             error: '',
             json: '',
+            isValid: false,
             showDialog: false,
         });
     }
@@ -69,6 +71,8 @@ class ImportStructDialog extends React.Component {
     onDialogHide() {
         this.setState({
             error: '',
+            json: '',
+            isValid: false,
             showDialog: false,
         });
     }
@@ -90,6 +94,10 @@ class ImportStructDialog extends React.Component {
         this.setState({ json: newValue });
     }
 
+    onValidate(isValid) {
+        this.setState({ isValid: isValid.length === 0 });
+    }
+
     /**
      * @inheritdoc
      */
@@ -102,6 +110,7 @@ class ImportStructDialog extends React.Component {
                     <Button
                         bsStyle="primary"
                         onClick={this.onImportJson}
+                        disabled={!this.state.isValid || this.state.json === ''}
                     >
                         Import
                     </Button>
@@ -110,11 +119,12 @@ class ImportStructDialog extends React.Component {
                 onHide={this.onDialogHide}
                 error={this.state.error}
             >
-
+                <p>Please enter a valid JSON to generate struct attributes</p>
                 <AceEditor
                     mode='json'
                     theme='monokai'
                     onChange={this.textChange}
+                    onValidate={this.onValidate}
                     value={this.state.json}
                     name='json'
                     editorProps={{
@@ -123,7 +133,7 @@ class ImportStructDialog extends React.Component {
                     setOptions={{
                         showLineNumbers: false,
                     }}
-                    maxLines={Infinity}
+                    maxLines={30}
                     minLines={10}
                     width='auto'
                     showPrintMargin={false}

--- a/modules/web/src/plugins/import-struct/plugin.js
+++ b/modules/web/src/plugins/import-struct/plugin.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import Plugin from 'core/plugin/plugin';
+import { CONTRIBUTIONS } from 'core/plugin/constants';
+import { read } from 'core/workspace/fs-util';
+import { COMMANDS as WORKSPACE_COMMANDS } from 'core/workspace/constants';
+import DefaultNodeFactory from 'ballerina/model/default-node-factory';
+import NodeFactory from 'ballerina/model/node-factory';
+import { PLUGIN_ID, DIALOG } from './constants';
+import ImportStructDialog from './dialogs/import-struct-dialog';
+
+/**
+ * Help plugin.
+ *
+ * @class HelpPlugin
+ */
+class ImportStructPlugin extends Plugin {
+
+    /**
+     * @inheritdoc
+     */
+    getID() {
+        return PLUGIN_ID;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    getContributions() {
+        const { DIALOGS } = CONTRIBUTIONS;
+        return {
+            [DIALOGS]: [
+                {
+                    id: DIALOG.IMPORT_STRUCT,
+                    component: ImportStructDialog,
+                    propsProvider: () => {
+                        return {
+                            importStructPlugin: this,
+                            extensions: ['json'],
+                        };
+                    },
+                },
+            ],
+        };
+    }
+}
+
+export default ImportStructPlugin;


### PR DESCRIPTION
This feature will add a button called "Import from JSON" in the Struct Definition view.

<img width="758" alt="screen shot 2017-10-27 at 10 36 26 am" src="https://user-images.githubusercontent.com/2918812/32088681-d51dac78-bb02-11e7-85a2-f20a1ee8b5e7.png">

User can provide a sample JSON on pop up dialog box 

<img width="752" alt="screen shot 2017-10-27 at 10 37 11 am" src="https://user-images.githubusercontent.com/2918812/32088694-ee8b83d8-bb02-11e7-976a-e6a16c34c45b.png">

Upon importing Struct fields will be generated from the JSON 

<img width="733" alt="screen shot 2017-10-27 at 10 37 26 am" src="https://user-images.githubusercontent.com/2918812/32088697-fd4f00e8-bb02-11e7-8de9-b36bd1f84431.png">
