### PR TITLE
Fix issue in loading composer in Safari

### DIFF
--- a/modules/web/src/core/utils/object-utils.js
+++ b/modules/web/src/core/utils/object-utils.js
@@ -1,9 +1,33 @@
 /**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import _ from 'lodash';
+
+/**
  * Make given object imutable
  *
  * @param {Object} object to freeze
+ * @return {Object} frozen object
  */
 export function makeImutable(o) {
+    if (_.isFunction(o)) {
+        return o;
+    }
     Object.freeze(o);
     Object.preventExtensions(0);
     if (o === undefined) {
@@ -16,6 +40,5 @@ export function makeImutable(o) {
             makeImutable(o[prop]);
         }
     });
-
     return o;
 }


### PR DESCRIPTION
Fixes : https://github.com/ballerinalang/composer/issues/4151

This issue was in arguments of a bound function throwing 'TypeError : 'arguments', 'callee', and 'caller' cannot be accessed in this context' during freezing. Fix is to avoid freezing functions.