### PR TITLE
Removing connector dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
                 <version>${ballerina.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.ballerina.connectors</groupId>
-                <artifactId>connectors</artifactId>
-                <version>${ballerina.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.ballerinalang</groupId>
                 <artifactId>ballerina-lang</artifactId>
                 <version>${ballerina.version}</version>


### PR DESCRIPTION
This dependency was not used by any sub modules. hence it should be safe to remove.