### PR TITLE
Fix rendering bound functions that are not in the builtin package

### DIFF
--- a/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-node-manager.js
+++ b/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-node-manager.js
@@ -231,7 +231,15 @@ class TransformNodeManager {
      * @memberof TransformNodeManager
      */
     getFunctionVertices(functionInvocationExpression) {
-        const fullPackageName = TreeUtil.getFullPackageName(functionInvocationExpression);
+        let fullPackageName = functionInvocationExpression.getFullPackageName();
+
+        if (!fullPackageName) {
+            // TODO: Fix obtaining the full package name for bound functions
+            // package name should be found through the receiver in bound functions
+            // but there is no straightforward way to get the variable def of the receiver
+            fullPackageName = TreeUtil.getFullPackageName(functionInvocationExpression);
+        }
+
         const funPackage = this._environment.getPackageByName(fullPackageName);
 
         if (!funPackage) {


### PR DESCRIPTION
At the moment bound functions that are not in the builtin package are not rendered in the transform expanded view.
This fixes it for the drag-drop case. However rendering directly from the source is still broken.