### PR TITLE
Transform save active state

### DIFF
--- a/modules/web/js/ballerina/diagram2/views/default/components/nodes/transformer-node.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/nodes/transformer-node.jsx
@@ -33,7 +33,7 @@ class TransformerNode extends React.Component {
 
     onExpand() {
         const { designView } = this.context;
-        designView.setTransformActive(true, this.props.model);
+        designView.setTransformActive(true, this.props.model.getSignature());
     }
 
     render() {

--- a/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-expanded.jsx
+++ b/modules/web/js/ballerina/diagram2/views/default/components/transform/transform-expanded.jsx
@@ -33,6 +33,7 @@ import { getLangServerClientInstance } from './../../../../../../langserver/lang
 import { getResolvedTypeData } from './../../../../../../langserver/lang-server-utils';
 import TreeUtil from '../../../../../model/tree-util';
 import DropZone from '../../../../../drag-drop/DropZone';
+import { CHANGE_EVT_TYPES } from 'ballerina/views/constants';
 import './transform-expanded.css';
 
 /**
@@ -603,6 +604,13 @@ class TransformExpanded extends React.Component {
     componentDidUpdate(prevProps, prevState) {
         this.transformNodeManager.setTransformStmt(this.props.model);
 
+        if (prevProps.model !== this.props.model) {
+            this.props.model.on(CHANGE_EVT_TYPES.TREE_MODIFIED, (evt) => {
+                const { designView } = this.context;
+                designView.setActiveTransformerSignature(this.props.model.getSignature());
+            })
+        }
+
         this.mapper.disconnectAll();
 
         let sourceKeys = Object.keys(this.sourceElements);
@@ -689,6 +697,13 @@ class TransformExpanded extends React.Component {
         this.mapper = new TransformRender(this.onConnectionCallback.bind(this),
             this.onDisconnectionCallback.bind(this), $(this.transformOverlayContentDiv));
 
+        this.props.model.on('tree-modified', (evt) => {
+            const { designView } = this.context;
+            // We keep info of what transformer is active by saving its signature
+            // any change that changes the signature should update this reference 
+            designView.setActiveTransformerSignature(this.props.model.getSignature());
+        });
+
         this.props.model.body.getStatements().forEach((statement) => {
             this.createConnection(statement);
         });
@@ -750,6 +765,7 @@ class TransformExpanded extends React.Component {
         if (this.scrollTimer) {
             clearInterval(this.scrollTimer);
         }
+        this.onClose();
     }
 
     onDragLeave(e) {

--- a/modules/web/js/ballerina/tool-palette/tool-view.jsx
+++ b/modules/web/js/ballerina/tool-palette/tool-view.jsx
@@ -69,7 +69,7 @@ class ToolView extends React.Component {
         let toolDesc = '';
         if (this.props.order === 'horizontal') {
             toolTip = tool.name;
-            toolDesc = tool.description;
+            toolDesc = tool.description || '';
             return this.props.connectDragSource(
                 <div
                     className="tool-block tool-container"

--- a/modules/web/js/ballerina/views/design-view.jsx
+++ b/modules/web/js/ballerina/views/design-view.jsx
@@ -28,6 +28,7 @@ import TransformExpanded from '../diagram2/views/default/components/transform/tr
 import CompilationUnitNode from './../model/tree/compilation-unit-node';
 import ToolPaletteView from './../tool-palette/tool-palette-view';
 import { TOOL_PALETTE_WIDTH } from './constants';
+import TreeUtil from 'ballerina/model/tree-util.js';
 
 class DesignView extends React.Component {
 
@@ -73,19 +74,30 @@ class DesignView extends React.Component {
     /**
     * Set the transform expanded view active state.
     * @param {boolean} isTransformActive - whether transform expanded view is active.
-    * @param {ASTNode} activeTransformModel - model related to expanded transform statement.
+    * @param {ASTNode} activeTransformSignature - signature of the transformer node related to expanded transform statement.
     * @memberof DesignView
     */
-    setTransformActive(isTransformActive, activeTransformModel) {
+    setTransformActive(isTransformActive, activeTransformSignature) {
         if (this.state.isTransformActive === isTransformActive &&
-            this.state.activeTransformModel === activeTransformModel) {
+            this.state.activeTransformSignature === activeTransformSignature) {
 
             return;
         }
 
         this.setState({
             isTransformActive,
-            activeTransformModel,
+            activeTransformSignature,
+        });
+    }
+
+    /**
+    * Set the active transformer signature
+    * @param {string} activeTransformSignature - signature of the transformer node related to expanded transformer statement.
+    * @memberof DesignView
+    */
+    setActiveTransformerSignature(activeTransformSignature) {
+        this.setState({
+            activeTransformSignature,
         });
     }
 
@@ -126,7 +138,16 @@ class DesignView extends React.Component {
     }
 
     render() {
-        const { isTransformActive, activeTransformModel } = this.state;
+        const { isTransformActive, activeTransformSignature } = this.state;
+
+        let activeTransformModel
+        if (isTransformActive) {
+            activeTransformModel = this.props.model.filterTopLevelNodes(
+                node => (TreeUtil.isTransformer(node))).find(node => (node.getSignature() === activeTransformSignature));
+        }
+
+        const shouldShowTransform = isTransformActive && activeTransformModel;
+
         return (
             <div className="design-view-container" style={{ display: this.props.show ? 'block' : 'none'}}>
                 <div className="outerCanvasDiv">
@@ -153,7 +174,7 @@ class DesignView extends React.Component {
                             </div>
                         </div>
                     </Scrollbars>
-                    {isTransformActive &&
+                    {shouldShowTransform &&
                         <TransformExpanded
                             model={activeTransformModel}
                             panelResizeInProgress={this.props.panelResizeInProgress}


### PR DESCRIPTION
Now the reference to the active transform node is kept by storing its signature. (source, target, params and name) (eg: "<Person p, Employee e> Bar (int age)")

This means any change from the split view that changes the signature will take user back to the normal design view. This also happens for undo/redo changes. However changes from design view itself are handled.