### PR TITLE
Gracefully handle runtime errors

### DIFF
--- a/modules/web/js/ballerina/views/ballerina-file-editor.jsx
+++ b/modules/web/js/ballerina/views/ballerina-file-editor.jsx
@@ -550,9 +550,9 @@ class BallerinaFileEditor extends React.Component {
                 });
                 // if syntax errors are found or model is not found
                 if (!_.isEmpty(syntaxErrors)
-                    || !_.isEmpty(runtimeFailures)
                     || _.isNil(data.model)
                     || _.isNil(data.model.kind)
+                    || (!_.isEmpty(runtimeFailures) && (_.isNil(data.model) || _.isNil(data.model.kind)))
                 ) {
                     newState.parseFailed = true;
                     newState.syntaxErrors = syntaxErrors;


### PR DESCRIPTION
Switch to source view upon RUNTIME
errors from parser, only if, there
is no model available to render.