### PR TITLE
Give the nextActive editor when closing a tab

### DIFF
--- a/modules/web/src/core/editor/plugin.js
+++ b/modules/web/src/core/editor/plugin.js
@@ -198,17 +198,22 @@ class EditorPlugin extends Plugin {
     /**
      * Closes a tab
      * @param {Editor} targetEditor Editor instance
+     * @param {Editor} nextActiveEditor Editor to be activated if the targetEditor is the active one. If not given the
+     *      editor to the left of targetEditor is activated.
      */
-    closeTab(targetEditor) {
+    closeTab(targetEditor, nextActiveEditor) {
         const { openedEditors, appContext: { workspace } } = this;
         const searchByID = editor => editor.id === targetEditor.id;
         // only change active editor when the closing one is the currently active one
         if (this.activeEditorID === targetEditor.id) {
-            const editorIndex = _.findIndex(openedEditors, searchByID);
-            const newActiveEditorIndex = editorIndex > 0 ? editorIndex - 1 : 1;
-            const newActiveEditor = !_.isNil(openedEditors[newActiveEditorIndex])
-                                    ? openedEditors[newActiveEditorIndex]
-                                    : undefined;
+            let newActiveEditor = nextActiveEditor;
+            if (!newActiveEditor) {
+                const editorIndex = _.findIndex(openedEditors, searchByID);
+                const newActiveEditorIndex = editorIndex > 0 ? editorIndex - 1 : 1;
+                newActiveEditor = !_.isNil(openedEditors[newActiveEditorIndex])
+                                        ? openedEditors[newActiveEditorIndex]
+                                        : undefined;
+            }
             _.remove(openedEditors, searchByID);
             this.setActiveEditor(newActiveEditor);
         } else {

--- a/modules/web/src/plugins/try-it/plugin.js
+++ b/modules/web/src/plugins/try-it/plugin.js
@@ -69,11 +69,8 @@ class TryItPlugin extends Plugin {
         command.on('debugger-stop-executed', () => {
             const tryItEditor = editor.getEditorByID(TRY_IT_VIEW.TRY_IT_VIEW_ID);
             if (tryItEditor) {
-                editor.closeEditor(tryItEditor);
                 const prevEditor = editor.getEditorByID(this.activeFile.fullPath);
-                if (prevEditor) {
-                    editor.setActiveEditor(prevEditor);
-                }
+                editor.closeEditor(tryItEditor, prevEditor);
             }
         });
     }


### PR DESCRIPTION
This fixes #4500

The issue occured because try-it and core plugins suplied different editors to be activated after closing try-it view.