### PR TITLE
Fix undo redo / dirty state glitches

### DIFF
--- a/modules/web/js/ballerina/views/source-editor.jsx
+++ b/modules/web/js/ballerina/views/source-editor.jsx
@@ -293,7 +293,7 @@ class SourceEditor extends React.Component {
             // Adding the file content changed event to the new file.
             nextProps.file.on(CONTENT_MODIFIED, this.onFileContentChanged);
             this.replaceContent(nextProps.file.content, true);
-        } else if (this.lastUpdatedTimestamp !== nextProps.file.lastUpdated) {
+        } else if (this.editor.session.getValue() !== nextProps.file.content) {
             this.replaceContent(nextProps.file.content, true);
         }
 


### PR DESCRIPTION
The issue was happening because [setContent](https://github.com/ballerinalang/composer/blob/3e5f90883b520aa8ffed50ef2746626471d9acd2/modules/web/js/ballerina/views/source-editor.jsx#L70) call in the undo manager triggers a rerender in source editor; and source editor [replaces](https://github.com/ballerinalang/composer/blob/master/modules/web/js/ballerina/views/source-editor.jsx#L297) the content again.
But this replacing does not trigger the execute method of undo manager, possibly because the content is the same. So the state we set to skip undo manager is never unset.