### PR TITLE
Styles for debugger frame name, fixes #4537

### DIFF
--- a/modules/web/src/plugins/debugger/views/Frames/frames.scss
+++ b/modules/web/src/plugins/debugger/views/Frames/frames.scss
@@ -98,8 +98,17 @@
     font-size: 14px;
     line-height: 23px;
 
-    .debug-frame-pkg-name{
+    .frame-title h4{
+        border-bottom: solid 1px #5f5f5f;
+        font-size: 14px;
+    }
+
+    .debug-frame-pkg-name {
         color: #03a9f4;
+    }
+
+    .fw-package {
+        padding: 5px;
     }
 
     .panel-title{

--- a/modules/web/src/plugins/debugger/views/Frames/index.jsx
+++ b/modules/web/src/plugins/debugger/views/Frames/index.jsx
@@ -127,8 +127,8 @@ class Frames extends React.Component {
                     {frames.map((frame, i) => {
                         return (
                             <div className="" key={frame.frameName}>
-                                <div className="">
-                                    <h4 className="panel-title">
+                                <div className="frame-title">
+                                    <h4>
                 
                                             {`${frame.frameName}`}
                                             <div className="debug-frame-pkg-name">


### PR DESCRIPTION
![selection_080](https://user-images.githubusercontent.com/1552869/32827559-a0d41d2a-ca12-11e7-971a-ac19751dbd62.png)
