### PR TITLE
Show conversion <> icon in the transformer connections

### DIFF
--- a/modules/web/js/ballerina/diagram/views/default/components/transform/transform-expanded.css
+++ b/modules/web/js/ballerina/diagram/views/default/components/transform/transform-expanded.css
@@ -57,9 +57,28 @@
     background: #666769;
 }
 
+.transformContextMenu {
+    position: fixed;
+    border: 1px solid #666769;
+    display: none;
+    background-color: #ffffff;
+}
+
+.transform-con-remove-button{
+    text-align: center;
+    padding: 5px;
+}
+
 .transform-con-remove {
     font-size: 0.94em;
     color: #666769;
+    display: inline-block;
+}
+
+.transform-con-cast-menu {
+  background: #575555;
+  color: #ffffff;
+  padding:5px;
 }
 
 .variable-edit-type {
@@ -196,4 +215,18 @@
 .btn-add-var {
   display: block;
   height: 30px;
+}
+
+.connectionLabel {
+  z-index: 30;
+  background:white;
+  padding: 2px;
+}
+
+.connectionLabel:hover {
+  z-index: 30;
+  color:#ff9900;
+  cursor:pointer;
+  background:white;
+  padding: 2px;
 }

--- a/modules/web/js/ballerina/diagram/views/default/components/transform/transform-expanded.jsx
+++ b/modules/web/js/ballerina/diagram/views/default/components/transform/transform-expanded.jsx
@@ -166,6 +166,7 @@ class TransformExpanded extends React.Component {
 
     createConnection(statement) {
         const viewId = this.props.model.getID();
+        let isCasting = false;
 
         if (TreeUtil.isComment(statement)) {
             return;
@@ -204,7 +205,7 @@ class TransformExpanded extends React.Component {
                     targetId = this.getFoldedEndpointId(targetExprString, viewId, 'target');
                 }
 
-                this.drawConnection(sourceId, targetId, folded);
+                this.drawConnection(sourceId, targetId, folded, statement);
             });
         }
         if (TreeUtil.isInvocation(expression) || TreeUtil.isBinaryExpr(expression)
@@ -303,7 +304,7 @@ class TransformExpanded extends React.Component {
                             targetId = `${nodeExpID}:${viewId}`;
                         }
 
-                        this.drawConnection(sourceId, targetId, folded);
+                        this.drawConnection(sourceId, targetId, folded, statement);
                     }
                 } else {
                     log.error('Unhandled rendering scenario');
@@ -340,7 +341,7 @@ class TransformExpanded extends React.Component {
                 targetId = this.getFoldedEndpointId(expression.getSource().trim(), viewId, 'target');
             }
 
-            this.drawConnection(sourceId, targetId, folded);
+            this.drawConnection(sourceId, targetId, folded, statement);
         });
         this.mapper.reposition(this.props.model.getID());
     }
@@ -455,7 +456,7 @@ class TransformExpanded extends React.Component {
                     targetId = `${nodeExpID}:${viewId}`;
                 }
 
-                this.drawConnection(sourceId, targetId, folded);
+                this.drawConnection(sourceId, targetId, folded, statement);
             }
         });
 
@@ -510,7 +511,7 @@ class TransformExpanded extends React.Component {
                 targetId = `${nodeExpID}:${viewId}`;
             }
 
-            this.drawConnection(sourceId, targetId, folded);
+            this.drawConnection(sourceId, targetId, folded, statement);
         }
     }
 
@@ -568,8 +569,12 @@ class TransformExpanded extends React.Component {
         return con;
     }
 
-    drawConnection(sourceId, targetId, folded) {
-        this.mapper.addConnection(sourceId, targetId, folded);
+    drawConnection(sourceId, targetId, folded, statement) {
+        let type = '';
+        if (statement !== null && statement.getExpression().getKind() === 'TypeConversionExpr') {
+            type = statement.getExpression().getTypeNode().getTypeKind();
+        }
+        this.mapper.addConnection(sourceId, targetId, folded, type);
     }
 
     createComplexProp(structName, expression) {

--- a/modules/web/js/ballerina/diagram/views/default/components/transform/transform-render.js
+++ b/modules/web/js/ballerina/diagram/views/default/components/transform/transform-render.js
@@ -264,16 +264,15 @@ class TransformRender {
             anchorTag.html($('<i>').addClass('fw fw-delete'));
             anchorTag.html(anchorTag.html() + ' Remove');
             contextMenuDiv.html('');
+            const removeButton = $('<div>').attr('class', 'transform-con-remove-button');
             if (typeCast !== '') {
-                contextMenuDiv.append($('<div>')
-                .attr('class', 'transform-con-cast-menu')
-                .append('Conversion : &lt;' + typeCast + '&gt'));
+                contextMenuDiv.append(removeButton.append('&lt;' + typeCast + '&gt'));
                 xDifMin = -150;
                 yDifMin = -60;
+            } else {
+                removeButton.append(anchorTag);
+                contextMenuDiv.append(removeButton);
             }
-            const removeButton = $('<div>').attr('class', 'transform-con-remove-button');
-            removeButton.append(anchorTag);
-            contextMenuDiv.append(removeButton);
             this.container.find('.leftType, .middle-content, .rightType').scroll(() => {
                 this.hideConnectContextMenu(this.container.find('#' + this.contextMenu));
             });

--- a/modules/web/js/ballerina/diagram/views/default/components/transform/transform-statement.css
+++ b/modules/web/js/ballerina/diagram/views/default/components/transform/transform-statement.css
@@ -126,15 +126,6 @@ svg.plumbConnect path {
     border: none !important;
     color: #f17b31 !important;
 }
-
-.transformContextMenu {
-    position: fixed;
-    border: 1px solid #666769;
-    padding: 5px;
-    display: none;
-    background-color: #ffffff;
-}
-
 .func-output {
     width: 150px;
     height: calc(100% - 33px);


### PR DESCRIPTION
Following fixes will add <> icon to connections. On mouse hover the converted type will be showing.
In future this menu will be improved to support select multiple conversions including reusing transformers.

![screen shot 2017-11-24 at 2 37 08 pm](https://user-images.githubusercontent.com/2918812/33203114-02a26c78-d125-11e7-975e-413e3b1bb5e4.png)
