### PR TITLE
Fix scroll going to the top when semicolon is hit in expression editor

### DIFF
--- a/modules/web/src/plugins/ballerina/expression-editor/expression-editor-utils.js
+++ b/modules/web/src/plugins/ballerina/expression-editor/expression-editor-utils.js
@@ -256,7 +256,10 @@ class ExpressionEditor {
 
                     didSemicolon = true;
                     props.model.trigger('focus-out');
-                    this.destroy();
+                    setTimeout(() => {
+                        this.destroy();
+                    }, 0);
+
                     if (_.isFunction(callback)) {
                         callback(text);
                     }


### PR DESCRIPTION
Fixes #4715