### PR TITLE
improve add menu with icon support and component restructure

### DIFF
--- a/modules/web/src/plugins/ballerina/interactions/button.jsx
+++ b/modules/web/src/plugins/ballerina/interactions/button.jsx
@@ -17,64 +17,42 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import './button.scss';
+import './interaction.scss';
 
+/**
+ * Interaction button component
+ */
 class Button extends React.Component {
-    /**
-     * draw add typed button
-     * @return {object} button rendering object
-     */
-    drawAddButton() {
-        const menuItems = ['If', 'While', 'Send', 'Receive'];
-        const width = this.props.width;
-        const height = this.props.height;
-        const x = this.props.x;
-        const y = this.props.y;
-        const buttonX = this.props.buttonX;
-        const buttonY = this.props.buttonY;
-        let buttonClass = 'button';
-        if (this.props.showAlways) {
-            buttonClass = 'button-show-always';
-        }
-
-        return (
-            <div
-                className='button-area'
-                style={{ height, width, left: x, top: y }}
-            >
-                <div className='interaction-menu-area' style={{ left: buttonX, top: buttonY }}>
-                    <div className='button-panel'>
-                      <span className={buttonClass + ' fw-stack fw-lg'} onClick={this.onAddButtonClick}>
-                          <i className='fw fw-circle fw-stack-2x' />
-                          <i className='fw fw-add fw-stack-1x fw-inverse' />
-                      </span>
-                    </div>
-                    <nav className='interaction-menu'>
-                        {
-                          menuItems.map((item) => {
-                              return (<a className='interaction-menu-item'>{item}</a>);
-                          })
-                        }
-                    </nav>
-                </div>
-            </div>
-        );
-    }
-
     /**
      * render hover area and button
      * @return {object} button rendering object
      */
     render() {
-        return this.drawAddButton();
+        const bBox = this.props.bBox;
+        const buttonX = this.props.buttonX;
+        const buttonY = this.props.buttonY;
+        return (
+            <div
+                className='button-area'
+                style={{ height: bBox.h, width: bBox.w, left: bBox.x, top: bBox.y }}
+            >
+                <div className='interaction-menu-area' style={{ left: buttonX, top: buttonY }}>
+                    <div className='button-panel'>
+                        <span className={(this.props.showAlways ? 'button-show-always' : 'button') + ' fw-stack fw-lg'}>
+                            <i className='fw fw-circle fw-stack-2x' />
+                            <i className='fw fw-add fw-stack-1x fw-inverse' />
+                        </span>
+                    </div>
+                    {this.props.children}
+                </div>
+            </div>
+        );
     }
 }
 
 Button.propTypes = {
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
-    width: PropTypes.number.isRequired,
-    height: PropTypes.number.isRequired,
+    children: PropTypes.isRequired,
+    bBox: PropTypes.valueOf(PropTypes.object).isRequired,
     buttonX: PropTypes.number,
     buttonY: PropTypes.number,
     showAlways: PropTypes.bool,

--- a/modules/web/src/plugins/ballerina/interactions/interaction.scss
+++ b/modules/web/src/plugins/ballerina/interactions/interaction.scss
@@ -5,7 +5,7 @@
 
 .interaction-menu-area {
     position:absolute;
-    width: 120px;
+    width: 150px;
     -webkit-clip-path: circle(24px at 30px 24px);
     clip-path: circle(12px at 13px 13px);
     -webkit-transition: -webkit-clip-path 0.5, clip-path 0.1;
@@ -54,17 +54,22 @@
 }
 
 .interaction-menu-area:hover .interaction-menu {
+    opacity: 1;
     display: block;
     background: #eeeeee;
     position: relative;
     float:left;
 }
 
-.interaction-menu-item {
+.interaction-menu-area:hover .interaction-menu-item {
     opacity: 1;
+}
+
+.interaction-menu-item {
+    opacity: 0;
     display: block;
     line-height: 30px;
-    padding: 0 24px;
+    padding: 0 10px;
     color: inherit;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -79,4 +84,8 @@
 
 .interaction-menu-item:active {
     background: #ffca28;
+}
+
+.button-icon {
+    padding-right: 5px;
 }

--- a/modules/web/src/plugins/ballerina/interactions/item.jsx
+++ b/modules/web/src/plugins/ballerina/interactions/item.jsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Interaction menu item component
+ */
+class Item extends React.Component {
+    /**
+     * render hover area and button
+     * @return {object} button rendering object
+     */
+    render() {
+        return (
+            <a
+                className='interaction-menu-item'
+                onClick={() => { this.props.callback(this.props.data); }}
+            >{this.props.icon !== '' && <i className={'button-icon ' + this.props.icon} />}{this.props.label}</a>);
+    }
+}
+
+Item.propTypes = {
+    icon: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    callback: PropTypes.valueOf(PropTypes.object),
+    data: PropTypes.valueOf(PropTypes.object),
+};
+
+Item.defaultProps = {
+    callback: () => {},
+    data: {},
+    icon: '',
+};
+
+export default Item;

--- a/modules/web/src/plugins/ballerina/interactions/menu.jsx
+++ b/modules/web/src/plugins/ballerina/interactions/menu.jsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Interaction menu component
+ */
+class Menu extends React.Component {
+    /**
+     * render hover area and button
+     * @return {object} button rendering object
+     */
+    render() {
+        return (
+            <nav className='interaction-menu'>
+                {this.props.children}
+            </nav>
+        );
+    }
+}
+
+Menu.propTypes = {
+    children: PropTypes.isRequired,
+};
+
+export default Menu;


### PR DESCRIPTION
Following sample code piece could be used to render components

```
<Button
    bBox={{ x: 100, y: 200, h: 50, w: 100 }}
    buttonX={30}
    buttonY={20}
   showAlways
>
    <Menu>
        <Item
            label='If'
            icon='fw fw-dgm-if-else'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'if condition' }}
        />
        <Item
            label='While'
            icon='fw fw-dgm-while'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'while condition' }}
        />
        <Item
            label='Send'
            icon='fw fw-worker-invoke'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'send stmt' }}
        />
        <Item
            label='Receive'
            icon='fw fw-worker-reply'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'receive stmt' }}
        />
    </Menu>
</Button>
```
Rendered screenshot of above sample code

![screen shot 2017-12-20 at 4 46 59 pm](https://user-images.githubusercontent.com/2918812/34204639-70bff11e-e5a5-11e7-8ba6-8a9bcd43f992.png)
