### PR TITLE
Design view improvements

### DIFF
--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -1291,6 +1291,11 @@
     .panel-label {
         dominant-baseline: middle;
     }
+
+    .client-line-text {
+        text-anchor: middle;
+        dominant-baseline: central;
+    }
     
     .condition-text {
         text-anchor: middle;

--- a/modules/web/src/plugins/ballerina/diagram/diagram-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/diagram-util.js
@@ -92,11 +92,7 @@ function getComponentForNodeArray(nodeArray, mode = 'default') {
         if (child.viewState && child.viewState.hidden) {
             return undefined;
         }
-
-        let compName = child.constructor.name;
-        if (child.viewState.alias !== undefined) {
-            compName = child.viewState.alias;
-        }
+        const compName = child.viewState.alias || child.constructor.name;
 
         if (components[mode][compName]) {
             return React.createElement(components[mode][compName], {
@@ -113,6 +109,7 @@ function getComponentForNodeArray(nodeArray, mode = 'default') {
                 key: child.getID(),
             }, null);
         }
+        return undefined;
     });
 }
 

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-invocation-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-invocation-decorator.jsx
@@ -27,6 +27,9 @@ import Breakpoint from './breakpoint';
 import ActiveArbiter from './active-arbiter';
 import Node from '../../../../../model/tree/node';
 import DropZone from '../../../../../drag-drop/DropZone';
+import ArrowDecorator from './arrow-decorator';
+import StatementPropertyItemSelector from './../utils/statement-property-item-selector';
+import TreeUtil from '../../../../../model/tree-util';
 import splitVariableDefByLambda from '../../../../../model/lambda-util';
 import { getComponentForNodeArray } from '../../../../diagram-util';
 
@@ -34,7 +37,7 @@ import { getComponentForNodeArray } from '../../../../diagram-util';
  * Wraps other UI elements and provide box with a heading.
  * Enrich elements with a action box and expression editors.
  */
-class StatementDecorator extends React.Component {
+class ActionInvocationDecorator extends React.Component {
 
     /**
      * Calculate statement box.
@@ -60,7 +63,7 @@ class StatementDecorator extends React.Component {
 
         this.state = {
             active: 'hidden',
-            statementBox: StatementDecorator.calculateStatementBox(props),
+            statementBox: ActionInvocationDecorator.calculateStatementBox(props),
         };
     }
 
@@ -69,7 +72,7 @@ class StatementDecorator extends React.Component {
      * @param {object} props - Next props.
      */
     componentWillReceiveProps(props) {
-        this.setState({ statementBox: StatementDecorator.calculateStatementBox(props) });
+        this.setState({ statementBox: ActionInvocationDecorator.calculateStatementBox(props) });
     }
 
     /**
@@ -152,7 +155,6 @@ class StatementDecorator extends React.Component {
         const dropZone = viewState.components['drop-zone'];
         const text = viewState.components.text;
 
-        const textClassName = 'statement-text';
         const actionBoxBbox = new SimpleBBox();
 
         const { designer } = this.context;
@@ -165,6 +167,43 @@ class StatementDecorator extends React.Component {
         if (viewState.fullExpression !== expression) {
             const fullExp = _.trimEnd(this.props.viewState.fullExpression, ';');
             tooltip = (<title>{fullExp}</title>);
+        }
+
+        let dropDownItems;
+        const dropDownItemMeta = [];
+        let backwardArrowStart;
+        let backwardArrowEnd;
+        if (viewState.isActionInvocation) {
+            // TODO: Need to remove the unique by filter whne the lang server item resolver is implemented
+            dropDownItems = _.uniqBy(TreeUtil.getAllVisibleEndpoints(this.props.model.parent), (item) => {
+                return item.variable.name.value;
+            });
+            dropDownItems.forEach((item) => {
+                const meta = {
+                    text: _.get(item, 'variable.name.value'),
+                    callback: (newEp) => {
+                        TreeUtil.changeInvocationEndpoint(this.props.model, newEp);
+                        this.props.model.trigger('tree-modified', {
+                            origin: this.props.model,
+                            type: 'invocation-endpoint-change',
+                            title: 'Change Target Endpoint',
+                            data: {
+                                node: this.props.model,
+                            },
+                        });
+                    },
+                };
+                dropDownItemMeta.push(meta);
+            });
+            this.props.model.getSource();
+
+            if (viewState.components.invocation) {
+                backwardArrowStart = Object.assign({}, viewState.components.invocation.end);
+                backwardArrowStart.y = viewState.components['statement-box'].y
+                    + viewState.components['statement-box'].h - 10;
+                backwardArrowEnd = Object.assign({}, viewState.components.invocation.start);
+                backwardArrowEnd.y = backwardArrowStart.y;
+            }
         }
 
         const { lambdas } = splitVariableDefByLambda(this.props.model);
@@ -207,15 +246,24 @@ class StatementDecorator extends React.Component {
                     enableDragBg
                     enableCenterOverlayLine
                 />
-                <g className='statement-body'>
-                    {tooltip}
-                    <text
-                        x={text.x}
-                        y={text.y}
-                        className={textClassName}
+                <g>
+                    <rect
+                        x={statementBox.x}
+                        y={statementBox.y}
+                        width={statementBox.w}
+                        height={statementBox.h}
+                        className='action-invocation-statement-rect'
                         onClick={e => this.openEditor(e)}
                     >
-                        {_.trimEnd(expression, ';')}
+                        {tooltip}
+                    </rect>
+                    <text
+                        x={viewState.components.invocation.start.x
+                            + this.context.designer.config.statement.padding.left}
+                        y={statementBox.y}
+                        className='action-invocation-text'
+                    >
+                        {expression}
                     </text>
                 </g>
                 <ActionBox
@@ -226,6 +274,23 @@ class StatementDecorator extends React.Component {
                     onJumptoCodeLine={() => this.onJumpToCodeLine()}
                     onBreakpointClick={() => this.props.onBreakpointClick()}
                 />
+                <g>
+                    <ArrowDecorator
+                        start={viewState.components.invocation.start}
+                        end={viewState.components.invocation.end}
+                    />
+                    <ArrowDecorator
+                        start={backwardArrowStart}
+                        end={backwardArrowEnd}
+                        dashed
+                    />
+                </g>
+                <StatementPropertyItemSelector
+                    model={this.props.model}
+                    bBox={this.props.model.viewState.components.dropDown}
+                    itemsMeta={dropDownItemMeta}
+                    show={this.state.active}
+                />
                 {isBreakpoint && this.renderBreakpointIndicator()}
                 {this.props.children}
             </g>);
@@ -233,12 +298,12 @@ class StatementDecorator extends React.Component {
 
 }
 
-StatementDecorator.defaultProps = {
+ActionInvocationDecorator.defaultProps = {
     editorOptions: null,
     children: null,
 };
 
-StatementDecorator.propTypes = {
+ActionInvocationDecorator.propTypes = {
     viewState: PropTypes.shape({
         bBox: PropTypes.instanceOf(SimpleBBox),
         fullExpression: PropTypes.string,
@@ -258,7 +323,7 @@ StatementDecorator.propTypes = {
     isBreakpoint: PropTypes.bool.isRequired,
 };
 
-StatementDecorator.contextTypes = {
+ActionInvocationDecorator.contextTypes = {
     getOverlayContainer: PropTypes.instanceOf(Object).isRequired,
     editor: PropTypes.instanceOf(Object).isRequired,
     environment: PropTypes.instanceOf(Object).isRequired,
@@ -268,4 +333,4 @@ StatementDecorator.contextTypes = {
 };
 
 
-export default breakpointHoc(StatementDecorator);
+export default breakpointHoc(ActionInvocationDecorator);

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-invocation-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-invocation-decorator.jsx
@@ -260,7 +260,8 @@ class ActionInvocationDecorator extends React.Component {
                     <text
                         x={viewState.components.invocation.start.x
                             + this.context.designer.config.statement.padding.left}
-                        y={statementBox.y}
+                        y={viewState.components.invocation.start.y
+                            - (this.context.designer.config.actionInvocationStatement.textHeight / 2)}
                         className='action-invocation-text'
                     >
                         {expression}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client.jsx
@@ -18,29 +18,17 @@
 
 
 import React from 'react';
-import _ from 'lodash';
 import PropTypes from 'prop-types';
-import ExpressionEditor from 'plugins/ballerina/expression-editor/expression-editor-utils';
-import SimpleBBox from './../../../../../model/view/simple-bounding-box';
-import { lifeLine } from './../../designer-defaults';
-import * as DesignerDefaults from './../../designer-defaults';
-import TreeUtils from './../../../../../model/tree-util';
-import OverlayComponentsRenderingUtil from './../utils/overlay-component-rendering-util';
-import ActionBox from './action-box';
-import ActiveArbiter from './active-arbiter';
+import { lifeLine, clientLine } from './../../designer-defaults';
 
 class Client extends React.Component {
-
-    constructor(props) {
-        super(props);
-    }
 
     render() {
         const bBox = this.props.bBox;
         const topBox = Object.assign({}, bBox);
         const bottomBox = Object.assign({}, bBox);
 
-        const header = 40;
+        const hLength = clientLine.head.length;
         bottomBox.h = lifeLine.head.height;
         topBox.h = lifeLine.head.height;
 
@@ -48,10 +36,16 @@ class Client extends React.Component {
 
         // calculate the line coordinates
         const line = {};
-        line.x1 = (header / 2) + bBox.x;
-        line.x2 = (header / 2) + bBox.x;
+        line.x1 = (hLength / 2) + bBox.x;
+        line.x2 = (hLength / 2) + bBox.x;
         line.y1 = bBox.y;
         line.y2 = bBox.y + bBox.h;
+
+
+        const topHeaderCentreX = bBox.x + (hLength / 2);
+        const topHeaderCentreY = topBox.y;
+        const bottomHeaderCentreX = topHeaderCentreX;
+        const bottomHeaderCentreY = bBox.y + bBox.h;
 
         const invokeLineY = topBox.y + topBox.h + this.context.designer.config.statement.height;
 
@@ -66,38 +60,34 @@ class Client extends React.Component {
                 className='client-life-line unhoverable'
             />
             <rect
-                x={topBox.x}
-                y={topBox.y}
-                width={header}
-                height={header}
+                x={topHeaderCentreX - (hLength / 2)}
+                y={topHeaderCentreY - (hLength / 2)}
+                width={hLength}
+                height={hLength}
                 rx='3'
                 ry='3'
                 className='client-line-header'
-                transform={`translate(${header / 2} -${header / 2}) rotate(45 ${topBox.x} ${topBox.y})`}
+                transform={`rotate(45 ${topHeaderCentreX} ${topHeaderCentreY})`}
             />
             <rect
-                x={bottomBox.x}
-                y={bottomBox.y}
-                width={header}
-                height={header}
+                x={bottomHeaderCentreX - (hLength / 2)}
+                y={bottomHeaderCentreY - (hLength / 2)}
+                width={hLength}
+                height={hLength}
                 rx='3'
                 ry='3'
                 className='client-line-header'
-                transform={`translate(${header / 2}) rotate(45 ${bottomBox.x} ${bottomBox.y})`}
+                transform={`rotate(45 ${bottomHeaderCentreX} ${bottomHeaderCentreY})`}
             />
             <text
-                x={topBox.x + 10}
-                y={topBox.y + 10}
-
-                dominantBaseline='central'
-                className='client-line-text genericT'
+                x={topHeaderCentreX}
+                y={topHeaderCentreY}
+                className='client-line-text'
             >{this.props.title}</text>
             <text
-                x={bottomBox.x + 10}
-                y={bottomBox.y + 30}
-
-                dominantBaseline='central'
-                className='client-line-text genericT'
+                x={bottomHeaderCentreX}
+                y={bottomHeaderCentreY}
+                className='client-line-text'
             >{this.props.title}</text>
             <line
                 x1={line.x1}
@@ -111,18 +101,23 @@ class Client extends React.Component {
                 x={line.x1 + this.context.designer.config.statement.gutter.h}
                 y={topBox.y + topBox.h + (this.context.designer.config.statement.height / 2)}
                 dominantBaseline='central'
-                className='client-line-text genericT'
             >{bBox.text}</text>
         </g>);
     }
 }
 
 Client.propTypes = {
-    editorOptions: PropTypes.shape(),
+    title: PropTypes.string,
+    bBox: PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+        w: PropTypes.number.isRequired,
+        h: PropTypes.number.isRequired,
+    }).isRequired,
 };
 
 Client.defaultProps = {
-    editorOptions: null,
+    title: 'Caller',
 };
 
 Client.contextTypes = {

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
@@ -228,7 +228,7 @@ class LifeLine extends React.Component {
                 y={bBox.y + titleBoxH / 2}
                 alignmentBaseline='central'
                 dominantBaseline='central'
-                className='life-line-text genericT'
+                className='life-line-text'
                 onClick={e => this.openExpressionEditor(e)}
             >{identifier}</text>
             <text
@@ -237,7 +237,7 @@ class LifeLine extends React.Component {
                 textAnchor='middle'
                 alignmentBaseline='central'
                 dominantBaseline='central'
-                className='life-line-text genericT unhoverable'
+                className='life-line-text'
             >{identifier}</text>
             {this.props.onDelete &&
                 <ActionBox

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-invocation-node.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-invocation-node.jsx
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import ActionInvocationDecorator from '../decorators/action-invocation-decorator';
+import ActiveArbiter from '../decorators/active-arbiter';
+
+/**
+ * Action Invocation Node component. This is a custom component for rendering all statements
+ * with an action invocation expression.
+ * Includes : assignment node, var def node and invocation statements with action invocations.
+ * */
+class ActionInvocationNode extends React.Component {
+
+
+    constructor(props) {
+        super(props);
+        this.editorOptions = {
+            propertyType: 'text',
+            key: 'Assignment',
+            model: this.props.model,
+        };
+    }
+
+    /**
+     * ToDo Update the edited expression
+     */
+    updateExpression(value) {
+    }
+
+    /**
+     * Render Function for the assignment statement.
+     * */
+    render() {
+        const model = this.props.model;
+        let expression = model.viewState.expression;
+
+        if (model.viewState.isActionInvocation) {
+            expression = model.getExpression().getInvocationSignature();
+        }
+
+        return (
+            <ActionInvocationDecorator
+                model={model}
+                viewState={model.viewState}
+                expression={expression}
+                editorOptions={this.editorOptions}
+            />);
+    }
+}
+
+ActionInvocationNode.propTypes = {
+    model: PropTypes.instanceOf(Object).isRequired,
+};
+
+ActionInvocationNode.contextTypes = {
+    activeArbiter: PropTypes.instanceOf(ActiveArbiter).isRequired,
+    designer: PropTypes.instanceOf(Object).isRequired,
+};
+
+export default ActionInvocationNode;

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-node.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-node.jsx
@@ -47,11 +47,6 @@ class ActionNode extends React.Component {
         this.onMouseOver = this.onMouseOver.bind(this);
     }
 
-    canDropToPanelBody(dragSource) {
-        return TreeUtil.isEndpointTypeVariableDef(dragSource)
-            || TreeUtil.isWorker(dragSource);
-    }
-
     /**
      * Handles the mouse over event of the add action button
      */
@@ -66,6 +61,11 @@ class ActionNode extends React.Component {
         if (_.isEmpty(this.props.model.viewState.overlayContainer)) {
             this.setState({ style: 'hideResourceGroup' });
         }
+    }
+
+    canDropToPanelBody(dragSource) {
+        return TreeUtil.isEndpointTypeVariableDef(dragSource)
+            || TreeUtil.isWorker(dragSource);
     }
 
     render() {

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-node.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-node.jsx
@@ -19,16 +19,17 @@
 import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import LifeLineDecorator from './../decorators/lifeline.jsx';
+import LifeLine from '../decorators/lifeline';
 import PanelDecorator from './../decorators/panel-decorator';
+import Client from '../decorators/client';
 import { getComponentForNodeArray } from './../../../../diagram-util';
-import { lifeLine } from './../../designer-defaults';
 import ImageUtil from './../../../../image-util';
 import './service-definition.css';
 import TreeUtil from '../../../../../model/tree-util';
 import EndpointDecorator from '../decorators/endpoint-decorator';
 import StatementDropZone from '../../../../../drag-drop/DropZone';
 import AddActionNode from './add-action-node';
+import ActionNodeModel from '../../../../../model/tree/action-node';
 
 class ActionNode extends React.Component {
 
@@ -70,14 +71,8 @@ class ActionNode extends React.Component {
     render() {
         const bBox = this.props.model.viewState.bBox;
         const name = this.props.model.getName().value;
-        const statementContainerBBox = this.props.model.body.viewState.bBox;
         const bodyBBox = this.props.model.body.viewState.bBox;
         const body = this.props.model.getBody();
-        const action_worker_bBox = {};
-        action_worker_bBox.x = statementContainerBBox.x + (statementContainerBBox.w - lifeLine.width) / 2;
-        action_worker_bBox.y = statementContainerBBox.y - lifeLine.head.height;
-        action_worker_bBox.w = lifeLine.width;
-        action_worker_bBox.h = statementContainerBBox.h + lifeLine.head.height * 2;
 
         const classes = {
             lineClass: 'default-worker-life-line',
@@ -118,6 +113,10 @@ class ActionNode extends React.Component {
                     argumentParams={argumentParameters}
                     returnParams={returnParameters}
                 >
+                    <Client
+                        title='Caller'
+                        bBox={this.props.model.viewState.components.client}
+                    />
                     <g>
                         { this.props.model.getWorkers().length === 0 &&
                             <g>
@@ -130,9 +129,9 @@ class ActionNode extends React.Component {
                                     dropTarget={body}
                                     enableDragBg
                                 />
-                                <LifeLineDecorator
+                                <LifeLine
                                     title='default'
-                                    bBox={action_worker_bBox}
+                                    bBox={this.props.model.viewState.components.defaultWorkerLine}
                                     classes={classes}
                                     icon={ImageUtil.getSVGIconString('tool-icons/worker-white')}
                                     iconColor='#025482'
@@ -181,6 +180,10 @@ class ActionNode extends React.Component {
 ActionNode.contextTypes = {
     editor: PropTypes.instanceOf(Object).isRequired,
     mode: PropTypes.string,
+};
+
+ActionNode.propTypes = {
+    model: PropTypes.instanceOf(ActionNodeModel).isRequired,
 };
 
 export default ActionNode;

--- a/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
@@ -102,6 +102,12 @@ export const lifeLine = {
     },
 };
 
+export const clientLine = {
+    head: {
+        length: 40,
+    },
+};
+
 export const actionBox = {
     width: 66,
     height: 21,

--- a/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
@@ -134,6 +134,8 @@ export const statement = {
 
 export const actionInvocationStatement = {
     width: 8,
+    height: (2 * statement.height),
+    textHeight: statement.height,
 };
 
 export const blockStatement = {

--- a/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
@@ -59,7 +59,8 @@ class PositioningUtil {
             viewState.bBox.x -= (this.config.actionInvocationStatement.width / 2);
 
             arrowStartBBox.x = viewState.bBox.x + viewState.bBox.w;
-            arrowStartBBox.y = viewState.components['statement-box'].y + 10;
+            arrowStartBBox.y = viewState.components['statement-box'].y
+                                + this.config.actionInvocationStatement.textHeight;
 
             dropDown.x = arrowStartBBox.x;
             dropDown.y = viewState.components['statement-box'].y

--- a/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
@@ -37,9 +37,8 @@ class PositioningUtil {
         viewState.components.text.y = viewState.components['statement-box'].y +
             (viewState.components['statement-box'].h / 2);
 
-        //
         if (TreeUtil.statementIsInvocation(node)) {
-            // Set the view state property to manipulate at the statement decorator
+            // Set the view state property to manipulate at the action invocation decorator
             viewState.isActionInvocation = true;
             const arrowStartBBox = new SimpleBBox();
             const arrowEndBBox = new SimpleBBox();
@@ -54,6 +53,11 @@ class PositioningUtil {
             const endpoint = _.find(allVisibleEndpoints, (varDef) => {
                 return varDef.variable.name.value === variableRefName;
             });
+
+            // Move the x cordinates to centre align the action invocation statement
+            viewState.components['statement-box'].x -= (this.config.actionInvocationStatement.width / 2);
+            viewState.bBox.x -= (this.config.actionInvocationStatement.width / 2);
+
             arrowStartBBox.x = viewState.bBox.x + viewState.bBox.w;
             arrowStartBBox.y = viewState.components['statement-box'].y + 10;
 

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1057,6 +1057,7 @@ class SizingUtil {
      *
      */
     sizeInvocationNode(node) {
+        // Invocation nodes are sized in sizeExpressionStatementNode
         // Not implemented.
     }
 
@@ -1263,6 +1264,7 @@ class SizingUtil {
         if (TreeUtil.statementIsInvocation(node)) {
             viewState.bBox.w = this.config.actionInvocationStatement.width;
             viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
+            viewState.alias = 'ActionInvocationNode';
         }
     }
 
@@ -1323,6 +1325,11 @@ class SizingUtil {
     sizeExpressionStatementNode(node) {
         const viewState = node.viewState;
         this.sizeStatement(node.getSource(true), viewState);
+        if (TreeUtil.statementIsInvocation(node)) {
+            viewState.bBox.w = this.config.actionInvocationStatement.width;
+            viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
+            viewState.alias = 'ActionInvocationNode';
+        }
     }
 
 
@@ -1362,7 +1369,8 @@ class SizingUtil {
 
         if (timeoutStmt) {
             // Calculate timeout expression, parameter expression, keyword lengths.
-            timeoutStmt.viewState.components.expression = this.getTextWidth(node.getTimeOutExpression().getSource(true));
+            timeoutStmt.viewState.components.expression =
+                            this.getTextWidth(node.getTimeOutExpression().getSource(true));
             timeoutStmt.viewState.components.titleWidth = this.getTextWidth('timeout');
             timeoutStmt.viewState.components.parameter = this.getTextWidth(node.getTimeOutVariable().getSource(true));
             if (timeoutStmt.viewState.bBox.w > nodeWidth) {
@@ -1669,6 +1677,7 @@ class SizingUtil {
         if (TreeUtil.statementIsInvocation(node)) {
             viewState.bBox.w = this.config.actionInvocationStatement.width;
             viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
+            viewState.alias = 'ActionInvocationNode';
         }
     }
 

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -349,9 +349,9 @@ class SizingUtil {
     sizeEnumeratorNode(node) {
         // For argument parameters and return types in the panel decorator
         const paramViewState = node.viewState;
-        paramViewState.w = this.getTextWidth(node.getSource(), 0).w + 15;
+        paramViewState.w = this.getTextWidth(node.getSource(true), 0).w + 15;
         paramViewState.h = this.config.enumIdentifierStatement.height;
-        paramViewState.components.expression = this.getTextWidth(node.getSource(), 0);
+        paramViewState.components.expression = this.getTextWidth(node.getSource(true), 0);
 
         // Creating component for delete icon.
         paramViewState.components.deleteIcon = {};
@@ -509,7 +509,7 @@ class SizingUtil {
         let width = 0;
         if (parameters.length > 0) {
             for (let i = 0; i < parameters.length; i++) {
-                width += this.getTextWidth(parameters[i].getSource(), 0).w + 21;
+                width += this.getTextWidth(parameters[i].getSource(true), 0).w + 21;
             }
         }
 
@@ -591,7 +591,7 @@ class SizingUtil {
             const globals = astRoot.filterTopLevelNodes({ kind: 'Variable' })
                 .concat(astRoot.filterTopLevelNodes({ kind: 'Xmlns' }));
             globals.forEach((global) => {
-                const text = this.getTextWidth(global.getSource(), 0, 292).text;
+                const text = this.getTextWidth(global.getSource(true), 0, 292).text;
                 global.viewState.globalText = text;
             });
             height += topGutter + topBarHeight + importInputHeight +
@@ -685,7 +685,7 @@ class SizingUtil {
      */
     sizeRetryNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -819,7 +819,7 @@ class SizingUtil {
 
         // Set the globals to fit the globals container
         variables.forEach((global) => {
-            const text = this.getTextWidth(global.getSource(), 0, 295).text;
+            const text = this.getTextWidth(global.getSource(true), 0, 295).text;
             global.viewState.globalText = text;
         });
     }
@@ -895,7 +895,7 @@ class SizingUtil {
     sizeVariableNode(node) {
         // For argument parameters and return types in the panel decorator
         const paramViewState = node.viewState;
-        paramViewState.w = this.getTextWidth(node.getSource(), 0).w;
+        paramViewState.w = this.getTextWidth(node.getSource(true), 0).w;
         paramViewState.h = this.config.panelHeading.heading.height - 7;
 
             // Creating component for delete icon.
@@ -931,7 +931,7 @@ class SizingUtil {
      *
      */
     sizeXmlnsNode(node) {
-        this.sizeStatement(node.getSource(), node.viewState);
+        this.sizeStatement(node.getSource(true), node.viewState);
     }
 
     /**
@@ -951,13 +951,13 @@ class SizingUtil {
         const textWidth = this.getTextWidth(node.getSignature());
         viewState.titleWidth = textWidth.w;
 
-        const returnParams = _.join(node.getReturnParameters().map(ret => ret.getSource()), ',');
-        const typeText = `< ${node.getSourceParam().getSource()}, ${returnParams} >`;
+        const returnParams = _.join(node.getReturnParameters().map(ret => ret.getSource(true)), ',');
+        const typeText = `< ${node.getSourceParam().getSource(true)}, ${returnParams} >`;
         const typeTextDetails = this.getTextWidth(typeText, 0);
         viewState.typeText = typeTextDetails.text;
         viewState.typeTextWidth = typeTextDetails.w;
 
-        const params = _.join(node.getParameters().map(ret => ret.getSource()), ',');
+        const params = _.join(node.getParameters().map(ret => ret.getSource(true)), ',');
         const paramText = node.name.value ? `(${params})` : '';
         const paramTextDetails = this.getTextWidth(paramText, 0);
         viewState.paramText = paramTextDetails.text;
@@ -1245,7 +1245,7 @@ class SizingUtil {
      */
     sizeAbortNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -1257,7 +1257,7 @@ class SizingUtil {
      */
     sizeAssignmentNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
         this.adjustToLambdaSize(node, viewState);
 
         if (TreeUtil.statementIsInvocation(node)) {
@@ -1274,7 +1274,7 @@ class SizingUtil {
      */
     sizeBindNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
     /**
@@ -1299,7 +1299,7 @@ class SizingUtil {
      */
     sizeBreakNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
     /**
@@ -1310,7 +1310,7 @@ class SizingUtil {
      */
     sizeNextNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -1322,7 +1322,7 @@ class SizingUtil {
      */
     sizeExpressionStatementNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -1353,7 +1353,7 @@ class SizingUtil {
             // Calculate join keyword, parameter expression, expression lengths;
             joinStmt.viewState.components.titleWidth = this.getTextWidth('join');
             joinStmt.viewState.components.expression = this.getTextWidth(node.getJoinConditionString());
-            joinStmt.viewState.components.parameter = this.getTextWidth(node.getJoinResultVar().getSource());
+            joinStmt.viewState.components.parameter = this.getTextWidth(node.getJoinResultVar().getSource(true));
 
             if (joinStmt.viewState.bBox.w > node.viewState.bBox.w) {
                 nodeWidth = joinStmt.viewState.bBox.w;
@@ -1362,9 +1362,9 @@ class SizingUtil {
 
         if (timeoutStmt) {
             // Calculate timeout expression, parameter expression, keyword lengths.
-            timeoutStmt.viewState.components.expression = this.getTextWidth(node.getTimeOutExpression().getSource());
+            timeoutStmt.viewState.components.expression = this.getTextWidth(node.getTimeOutExpression().getSource(true));
             timeoutStmt.viewState.components.titleWidth = this.getTextWidth('timeout');
-            timeoutStmt.viewState.components.parameter = this.getTextWidth(node.getTimeOutVariable().getSource());
+            timeoutStmt.viewState.components.parameter = this.getTextWidth(node.getTimeOutVariable().getSource(true));
             if (timeoutStmt.viewState.bBox.w > nodeWidth) {
                 nodeWidth = timeoutStmt.viewState.bBox.w;
             }
@@ -1487,7 +1487,7 @@ class SizingUtil {
         if (expression) {
             // see how much space we have to draw the condition
             const available = bodyWidth - this.config.flowChartControlStatement.heading.width - 10;
-            components.expression = this.getTextWidth(expression.getSource(), 0, available);
+            components.expression = this.getTextWidth(expression.getSource(true), 0, available);
         }
 
         // end of if block sizing
@@ -1543,7 +1543,7 @@ class SizingUtil {
      */
     sizeReturnNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
         this.adjustToLambdaSize(node, viewState);
     }
 
@@ -1567,7 +1567,7 @@ class SizingUtil {
      */
     sizeThrowNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -1587,7 +1587,7 @@ class SizingUtil {
             if (node.condition) {
                 node.transactionBody.viewState.components.withKeywordWidth = this.getTextWidth('with');
                 node.transactionBody.viewState.components.retiresKeywordWidth = this.getTextWidth('retries');
-                node.viewState.components.expression = this.getTextWidth(node.condition.getSource());
+                node.viewState.components.expression = this.getTextWidth(node.condition.getSource(true));
             }
             node.viewState.components['statement-box'].h
                 += node.transactionBody.viewState.components['statement-box'].h;
@@ -1657,7 +1657,7 @@ class SizingUtil {
      */
     sizeVariableDefNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
         this.adjustToLambdaSize(node, viewState);
 
         // Truncate the endpoint name to fit the statement box
@@ -1723,7 +1723,7 @@ class SizingUtil {
         if (expression) {
             // see how much space we have to draw the condition
             const available = bodyWidth - this.config.flowChartControlStatement.heading.width - 10;
-            components.expression = this.getTextWidth(expression.getSource(), 0, available);
+            components.expression = this.getTextWidth(expression.getSource(true), 0, available);
         }
     }
 
@@ -1736,7 +1736,7 @@ class SizingUtil {
      */
     sizeWorkerReceiveNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -1748,7 +1748,7 @@ class SizingUtil {
      */
     sizeWorkerSendNode(node) {
         const viewState = node.viewState;
-        this.sizeStatement(node.getSource(), viewState);
+        this.sizeStatement(node.getSource(true), viewState);
     }
 
 
@@ -1875,7 +1875,7 @@ class SizingUtil {
         if (expression) {
             // see how much space we have to draw the condition
             const available = bodyWidth - this.config.blockStatement.heading.width - 10;
-            components.expression = this.getTextWidth(expression.getSource(), 0, available);
+            components.expression = this.getTextWidth(expression.getSource(true), 0, available);
         }
     }
 

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1677,6 +1677,8 @@ class SizingUtil {
             const viewState = node.viewState;
             viewState.bBox.w = this.config.actionInvocationStatement.width;
             viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
+            viewState.bBox.h = this.config.actionInvocationStatement.height;
+            viewState.components['statement-box'].h = this.config.actionInvocationStatement.height;
             viewState.alias = 'ActionInvocationNode';
         }
     }

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1260,12 +1260,7 @@ class SizingUtil {
         const viewState = node.viewState;
         this.sizeStatement(node.getSource(true), viewState);
         this.adjustToLambdaSize(node, viewState);
-
-        if (TreeUtil.statementIsInvocation(node)) {
-            viewState.bBox.w = this.config.actionInvocationStatement.width;
-            viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
-            viewState.alias = 'ActionInvocationNode';
-        }
+        this.sizeActionInvocationStatement(node);
     }
 
     /**
@@ -1325,11 +1320,7 @@ class SizingUtil {
     sizeExpressionStatementNode(node) {
         const viewState = node.viewState;
         this.sizeStatement(node.getSource(true), viewState);
-        if (TreeUtil.statementIsInvocation(node)) {
-            viewState.bBox.w = this.config.actionInvocationStatement.width;
-            viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
-            viewState.alias = 'ActionInvocationNode';
-        }
+        this.sizeActionInvocationStatement(node);
     }
 
 
@@ -1673,8 +1664,17 @@ class SizingUtil {
             const endpointWdth = 90;
             viewState.endpointIdentifier = this.getTextWidth(node.getVariable().getName().value, 0, endpointWdth).text;
         }
+        this.sizeActionInvocationStatement(node);
+    }
 
+    /**
+     * Size statements containing action invocation statements
+     * @param {node} node node to size
+     */
+    sizeActionInvocationStatement(node) {
+        // This function gets called by statements containing action invocation expressions
         if (TreeUtil.statementIsInvocation(node)) {
+            const viewState = node.viewState;
             viewState.bBox.w = this.config.actionInvocationStatement.width;
             viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
             viewState.alias = 'ActionInvocationNode';


### PR DESCRIPTION
This PR contains following improvements : 

- Hiding comments in design view
- Action node lifeline and client line rendering
- Client line design improvements
- Separating out action invocations from statement decorator
- Improve action invocation rendering

Before:
<img width="337" alt="image" src="https://user-images.githubusercontent.com/1029806/34213113-5ac73092-e5c4-11e7-8c7f-94a0fb125899.png">

Now: 
![image](https://user-images.githubusercontent.com/1029806/34213101-53e194fc-e5c4-11e7-8022-5dd2eff82b89.png)
