### PR TITLE
make button size configurable via props

### DIFF
--- a/modules/web/src/plugins/ballerina/interactions/button.jsx
+++ b/modules/web/src/plugins/ballerina/interactions/button.jsx
@@ -29,16 +29,23 @@ class Button extends React.Component {
      */
     render() {
         const bBox = this.props.bBox;
-        const buttonX = this.props.buttonX;
-        const buttonY = this.props.buttonY;
+        const btnX = this.props.buttonX;
+        const btnY = this.props.buttonY;
+        const btnRadius = this.props.buttonRadius;
         return (
             <div
                 className='button-area'
                 style={{ height: bBox.h, width: bBox.w, left: bBox.x, top: bBox.y }}
             >
-                <div className='interaction-menu-area' style={{ left: buttonX, top: buttonY }}>
-                    <div className='button-panel'>
-                        <span className={(this.props.showAlways ? 'button-show-always' : 'button') + ' fw-stack fw-lg'}>
+                <div
+                    className='interaction-menu-area'
+                    style={{ left: btnX, top: btnY, '--button-size': (btnRadius + 2 + (btnRadius / 4)) + 'px' }}
+                >
+                    <div style={{ fontSize: btnRadius }} className='button-panel'>
+                        <span
+
+                            className={(this.props.showAlways ? 'button-show-always' : 'button') + ' fw-stack fw-lg'}
+                        >
                             <i className='fw fw-circle fw-stack-2x' />
                             <i className='fw fw-add fw-stack-1x fw-inverse' />
                         </span>
@@ -55,12 +62,14 @@ Button.propTypes = {
     bBox: PropTypes.valueOf(PropTypes.object).isRequired,
     buttonX: PropTypes.number,
     buttonY: PropTypes.number,
+    buttonRadius: PropTypes.number,
     showAlways: PropTypes.bool,
 };
 
 Button.defaultProps = {
     buttonX: 20,
     buttonY: 20,
+    buttonRadius: 10,
     showAlways: false,
 };
 

--- a/modules/web/src/plugins/ballerina/interactions/interaction.scss
+++ b/modules/web/src/plugins/ballerina/interactions/interaction.scss
@@ -5,8 +5,8 @@
 
 .interaction-menu-area {
     position:absolute;
-    -webkit-clip-path: circle(24px at 30px 24px);
-    clip-path: circle(12px at 13px 13px);
+    -webkit-clip-path: circle(var(--button-size) at var(--button-size) var(--button-size));
+    clip-path: circle(var(--button-size) at var(--button-size) var(--button-size));
     -webkit-transition: -webkit-clip-path 0.5, clip-path 0.1;
     transition: -webkit-clip-path 0.5, clip-path 0.1;
 }
@@ -29,17 +29,16 @@
     top:2px;
     -webkit-animation: appear-button 0.2s ease-out;
     -moz-animation: appear-down 0.2s ease-out;
-    font-size:12px;
     cursor: pointer;
 }
 
 @-webkit-keyframes appear-button {
-      0% { opacity: 0;  font-size:5px }
-    100% { opacity: 1; font-size:12px}
+      0% { opacity: 0;  font-size:0% }
+    100% { opacity: 1; font-size:100%}
 }
 @-moz-keyframes appear-button {
-      0% { opacity: 0; font-size:5px}
-    100% { opacity: 1; font-size:12px }
+      0% { opacity: 0; font-size:0%}
+    100% { opacity: 1; font-size:100% }
 }
 
 .interaction-menu-area:hover {

--- a/modules/web/src/plugins/ballerina/interactions/interaction.scss
+++ b/modules/web/src/plugins/ballerina/interactions/interaction.scss
@@ -5,7 +5,6 @@
 
 .interaction-menu-area {
     position:absolute;
-    width: 150px;
     -webkit-clip-path: circle(24px at 30px 24px);
     clip-path: circle(12px at 13px 13px);
     -webkit-transition: -webkit-clip-path 0.5, clip-path 0.1;


### PR DESCRIPTION
Button size can be configured via props. You can use `buttonRadius` property as following sample code piece

```
<Button
    bBox={{ x: 100, y: 100, h: 500, w: 500 }}
    buttonX={0}
    buttonY={0}
    buttonRadius={20}
    showAlways
>
    <Menu>
        <Item
            label='If'
            icon='fw fw-dgm-if-else'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'if condition' }}
        />
        <Item
            label='While'
            icon='fw fw-dgm-while'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'while condition' }}
        />
        <Item
            label='Send'
            icon='fw fw-worker-invoke'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'send stmt' }}
        />
        <Item
            label='Receive'
            icon='fw fw-worker-reply'
            callback={(data) => { alert(data.name); }}
            data={{ name: 'receive stmt' }}
        />
    </Menu>
</Button>
```
Screenshot of Rendered view of above code

![screen shot 2017-12-21 at 4 32 14 pm](https://user-images.githubusercontent.com/2918812/34253068-1684fc7c-e66c-11e7-981e-a2a60ceac2bd.png)
