### PR TITLE
Fixes to design-view revamp

### DIFF
--- a/modules/web/scss/layout.scss
+++ b/modules/web/scss/layout.scss
@@ -1,2 +1,2 @@
-$header-min-height: 24px;
+$header-min-height: 30px;
 $activity-bar-width: 42px;

--- a/modules/web/scss/modules/header.scss
+++ b/modules/web/scss/modules/header.scss
@@ -9,7 +9,7 @@
         color: $header-brand-color;
         padding: 0 10px;
         margin-right: 25px;
-        line-height: 24px;
+        line-height: $header-min-height;
         
         & a {
             color: $header-brand-color;

--- a/modules/web/scss/modules/menu.scss
+++ b/modules/web/scss/modules/menu.scss
@@ -30,7 +30,7 @@
         border: none;
         box-shadow: none;
         border-radius: 0;
-        line-height: 24px;
+        line-height: $header-min-height;
         &.rc-menu-root {
             background: none;
         }

--- a/modules/web/src/core/layout/components/App.jsx
+++ b/modules/web/src/core/layout/components/App.jsx
@@ -36,8 +36,8 @@ const leftPanelMaxSize = 700;
 const leftPanelClosedSize = 42;
 const bottomPanelDefaultSize = 300;
 const bottomPanelMaxSize = 700;
-const headerHeight = 24;
-const toolAreaHeight = 30;
+const headerHeight = 30;
+const toolAreaHeight = 0;
 const resizerSize = 1;
 /**
  * React component for App.
@@ -188,12 +188,6 @@ class App extends React.Component {
                     panelResizeInProgress={this.state.panelResizeInProgress}
                     width={this.state.documentWidth}
                     height={headerHeight}
-                />
-                <ToolArea
-                    views={this.getViewsForRegion(REGIONS.TOOL_AREA)}
-                    panelResizeInProgress={this.state.panelResizeInProgress}
-                    width={this.state.documentWidth}
-                    height={toolAreaHeight}
                 />
                 <SplitPane
                     ref={(ref) => { this.leftRightSplitPane = ref; }}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-box.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-box.jsx
@@ -62,7 +62,7 @@ class ActionBox extends React.Component {
      */
     render() {
         const bBox = this.props.bBox;
-        const numIcons = 3 - (this.props.onBreakpointClick ? 0 : 1) - (this.props.isDefaultWorker ? 1 : 0);
+        const numIcons = 2 - (this.props.isDefaultWorker ? 1 : 0);
         const iconSize = 14;
         const y = bBox.y + ((bBox.h - iconSize) / 2);
         const horizontalGap = (bBox.w - (iconSize * numIcons)) / (numIcons + 1);
@@ -98,15 +98,6 @@ class ActionBox extends React.Component {
                 y={y}
             >
                 <title>Delete</title> </image> }
-            {this.props.onBreakpointClick &&
-            <Breakpoint
-                x={bBox.x + iconSize + (horizontalGap * 2)}
-                y={y}
-                size={iconSize}
-                isBreakpoint={this.props.isBreakpoint}
-                onClick={this.props.onBreakpointClick}
-            />
-                    }
             <image
                 width={iconSize}
                 height={iconSize}
@@ -131,8 +122,6 @@ ActionBox.propTypes = {
         h: PropTypes.number.isRequired,
     }).isRequired,
     show: PropTypes.string,
-    isBreakpoint: PropTypes.bool,
-    onBreakpointClick: PropTypes.func,
     onDelete: PropTypes.func.isRequired,
     onJumptoCodeLine: PropTypes.func.isRequired,
     disableButtons: PropTypes.shape({
@@ -147,8 +136,6 @@ ActionBox.propTypes = {
 
 ActionBox.defaultProps = {
     show: false,
-    isBreakpoint: false,
-    onBreakpointClick: undefined,
     disableButtons: {
         debug: false,
         delete: false,

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/panel-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/panel-decorator.jsx
@@ -139,25 +139,6 @@ class PanelDecorator extends React.Component {
 
         staticButtons.push(React.createElement(PanelDecoratorButton, deleteButtonProps, null));
 
-        // Creating show annotation button.
-        if (!TreeUtils.isTransformer(this.props.model)) {
-            const annotationButtonProps = {
-                bBox: {
-                    x: x - (width * (staticButtons.length + 1)),
-                    y,
-                    height,
-                    width,
-                },
-                icon: ImageUtil.getSVGIconString(this.props.model.viewState.showAnnotationContainer ?
-                    'annotation-clicked' : 'annotation'),
-                tooltip: this.props.model.viewState.showAnnotationContainer ? 'Hide Annotations' : 'Show Annotation',
-                onClick: () => this.toggleAnnotations(),
-                key: `${this.props.model.getID()}-show-annotation-button`,
-            };
-
-            staticButtons.push(React.createElement(PanelDecoratorButton, annotationButtonProps, null));
-        }
-
         if ((!TreeUtils.isMainFunction(this.props.model) && TreeUtils.isFunction(this.props.model)) ||
             TreeUtils.isStruct(this.props.model) || TreeUtils.isConnector(this.props.model) ||
             TreeUtils.isTransformer(this.props.model)) {

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/statement-decorator.css
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/statement-decorator.css
@@ -14,3 +14,7 @@
 .statement-item-selector {
     cursor: pointer;
 }
+
+.statement-body {
+    cursor: pointer;
+}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/statement-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/statement-decorator.jsx
@@ -207,13 +207,13 @@ class StatementDecorator extends React.Component {
                     enableDragBg
                     enableCenterOverlayLine
                 />
-                <g className='statement-body'>
+                <g className='statement-body' onClick={e => this.onJumpToCodeLine()}>
                     {tooltip}
                     <text
                         x={text.x}
                         y={text.y}
                         className={textClassName}
-                        onClick={e => this.openEditor(e)}
+                        onClick={e => this.onJumpToCodeLine()}
                     >
                         {_.trimEnd(expression, ';')}
                     </text>

--- a/modules/web/src/plugins/ballerina/diagram/views/default/controller-positioning-util.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/controller-positioning-util.jsx
@@ -97,7 +97,11 @@ class ControllerPositioningUtil {
      *
      */
     positionCompilationUnitNodeControllers(node) {
-        const x = this.config.panel.wrapper.gutter.h + 320;
+        const offsetX = node.getPackageDeclaration()
+                || node.viewState.packageDefExpanded
+                ? 320
+                : 40;
+        const x = this.config.panel.wrapper.gutter.h + offsetX;
         const y = this.config.panel.wrapper.gutter.v;
         const w = 50;
         const h = 50;

--- a/modules/web/src/plugins/ballerina/model/tree/compilation-unit-node.js
+++ b/modules/web/src/plugins/ballerina/model/tree/compilation-unit-node.js
@@ -170,6 +170,14 @@ class CompilationUnitNode extends AbstractCompilationUnitNode {
         }
         return empty;
     }
+
+    /**
+     * Returns the package declaration node
+     */
+    getPackageDeclaration() {
+        const pkgDecNodes = this.filterTopLevelNodes({ kind: 'PackageDeclaration' });
+        return _.isEmpty(pkgDecNodes) ? undefined : pkgDecNodes[0];
+    }
 }
 
 export default CompilationUnitNode;

--- a/modules/web/src/plugins/ballerina/plugin.js
+++ b/modules/web/src/plugins/ballerina/plugin.js
@@ -196,22 +196,6 @@ class BallerinaPlugin extends Plugin {
                     },
                     displayOnLoad: false,
                 },
-                {
-                    id: VIEW_IDS.TOOL_PALLETE,
-                    component: ToolPaletteView,
-                    propsProvider: () => {
-                        return {
-                            ballerinaPlugin: this,
-                        };
-                    },
-                    region: REGIONS.LEFT_PANEL,
-                    // region specific options for left-panel views
-                    regionOptions: {
-                        activityBarIcon: 'grip',
-                        panelTitle: 'Tool Palette',
-                        panelActions: [],
-                    },
-                },
             ],
             [HANDLERS]: [
                 {

--- a/modules/web/src/plugins/ballerina/views/source-editor.jsx
+++ b/modules/web/src/plugins/ballerina/views/source-editor.jsx
@@ -58,6 +58,7 @@ class SourceEditor extends React.Component {
         this.lastUpdatedTimestamp = props.file.lastUpdated;
         this.editorDidMount = this.editorDidMount.bind(this);
         this.onWorkspaceFileClose = this.onWorkspaceFileClose.bind(this);
+        this.handleGoToPosition = this.handleGoToPosition.bind(this);
     }
 
     /**
@@ -115,6 +116,7 @@ class SourceEditor extends React.Component {
      */
     componentWillUnmount() {
         this.props.commandProxy.off(WORKSPACE_EVENTS.FILE_CLOSED, this.onWorkspaceFileClose);
+        this.props.commandProxy.off(GO_TO_POSITION, this.handleGoToPosition);
     }
 
      /**
@@ -165,6 +167,7 @@ class SourceEditor extends React.Component {
         }
         editorInstance.setModel(modelForFile);
         this.props.commandProxy.on(WORKSPACE_EVENTS.FILE_CLOSED, this.onWorkspaceFileClose);
+        this.props.commandProxy.on(GO_TO_POSITION, this.handleGoToPosition);
         const services = createMonacoServices(editorInstance);
         const getLangServerConnection = this.props.ballerinaPlugin.getLangServerConnection();
         getLangServerConnection
@@ -205,7 +208,7 @@ class SourceEditor extends React.Component {
      */
     handleGoToPosition(args) {
         if (this.props.file.id === args.file.id) {
-            this.goToCursorPosition(args.row, args.column);
+            this.goToCursorPosition(args.row + 1, args.column + 1);
         }
     }
 
@@ -213,12 +216,15 @@ class SourceEditor extends React.Component {
      * Set cursor of the source editor to a
      * specific position.
      *
-     * @param {number} row Line Number
-     * @param {number} column Offset
+     * @param {number} lineNumber Line Number (1 based)
+     * @param {number} column Offset (1 based)
      */
-    goToCursorPosition(row, column) {
-        this.editor.focus();
-        this.editor.gotoLine(row + 1, column);
+    goToCursorPosition(lineNumber, column) {
+        this.editorInstance.focus();
+        this.editorInstance.setPosition({
+            lineNumber,
+            column,
+        });
     }
 
     /**


### PR DESCRIPTION
Fix positioning of top-level-nodes add btn
Remove debug action from action box
Remove annotation btn from panel header
Remove tool-palette
Remove tool-bar
Increate menu-bar height
Fix go-to-source for monaco
Disable stmt editing from design-view and enable go-to-source upon click
