### PR TITLE
Design view improvements/fixes

### DIFF
--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -1254,7 +1254,7 @@
     }
 
     .action-invocation-statement-rect {
-        fill: $default-worker-lifeline-color;
+        fill: $connector-lifeline-color;
         stroke-width: 1;
     }
     

--- a/modules/web/src/plugins/ballerina/diagram/views/action/positioning-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/action/positioning-util.js
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import _ from 'lodash';
 import DefaultPositioningUtil from '../default/positioning-util';
 import TreeUtil from './../../../model/tree-util';
 
@@ -60,7 +59,7 @@ class PositioningUtil extends DefaultPositioningUtil {
      *
      */
     positionReturnNode(node) {
-        // do nothing
+        super.positionReturnNode(node);
     }
 
     /**

--- a/modules/web/src/plugins/ballerina/diagram/views/action/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/action/sizing-util.js
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-// import _ from 'lodash';
 import DefaultSizingUtil from '../default/sizing-util';
 import SimpleBBox from './../../../model/view/simple-bounding-box';
 import TreeUtil from './../../../model/tree-util';
@@ -60,7 +59,8 @@ class SizingUtil extends DefaultSizingUtil {
             TreeUtil.statementIsInvocation(node) ||
             TreeUtil.isIf(node) ||
             TreeUtil.isWhile(node) ||
-            TreeUtil.isEndpointTypeVariableDef(node)
+            TreeUtil.isEndpointTypeVariableDef(node) ||
+            TreeUtil.statementIsClientResponder(node)
         ) {
             return true;
         }

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-invocation-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/action-invocation-decorator.jsx
@@ -171,8 +171,8 @@ class ActionInvocationDecorator extends React.Component {
 
         let dropDownItems;
         const dropDownItemMeta = [];
-        let backwardArrowStart;
-        let backwardArrowEnd;
+        const backwardArrowStart = {};
+        const backwardArrowEnd = {};
         if (viewState.isActionInvocation) {
             // TODO: Need to remove the unique by filter whne the lang server item resolver is implemented
             dropDownItems = _.uniqBy(TreeUtil.getAllVisibleEndpoints(this.props.model.parent), (item) => {
@@ -197,10 +197,10 @@ class ActionInvocationDecorator extends React.Component {
             });
 
             if (viewState.components.invocation) {
-                backwardArrowStart = Object.assign({}, viewState.components.invocation.end);
+                backwardArrowStart.x = viewState.components.invocation.end.x;
                 backwardArrowStart.y = viewState.components['statement-box'].y
                                 + viewState.components['statement-box'].h;
-                backwardArrowEnd = Object.assign({}, viewState.components.invocation.start);
+                backwardArrowEnd.x = statementBox.x + (designer.config.actionInvocationStatement.width / 2);
                 backwardArrowEnd.y = backwardArrowStart.y;
             }
         }
@@ -245,27 +245,26 @@ class ActionInvocationDecorator extends React.Component {
                     enableDragBg
                     enableCenterOverlayLine
                 />
-                <g>
-                    <rect
-                        x={statementBox.x}
-                        y={statementBox.y + (statementBox.h / 2)}
-                        width={statementBox.w}
-                        height={statementBox.h / 2}
-                        className='action-invocation-statement-rect'
-                        onClick={e => this.openEditor(e)}
-                    >
-                        {tooltip}
-                    </rect>
-                    <text
-                        x={statementBox.x + (statementBox.w / 2)
-                            + this.context.designer.config.statement.gutter.h}
-                        y={viewState.components.invocation.start.y
-                            - (this.context.designer.config.actionInvocationStatement.textHeight / 2)}
-                        className='action-invocation-text'
-                    >
-                        {expression}
-                    </text>
-                </g>
+                <text
+                    x={statementBox.x
+                        + (designer.config.actionInvocationStatement.width / 2)
+                        + designer.config.statement.gutter.h}
+                    y={viewState.components.invocation.start.y
+                        - (designer.config.actionInvocationStatement.textHeight / 2)}
+                    className='action-invocation-text'
+                    onClick={e => this.openEditor(e)}
+                >
+                    {expression}
+                </text>
+                <rect
+                    x={viewState.components.invocation.end.x}
+                    y={viewState.components.invocation.end.y}
+                    width={designer.config.actionInvocationStatement.width}
+                    height={statementBox.h / 2}
+                    className='action-invocation-statement-rect'
+                >
+                    {tooltip}
+                </rect>
                 <ActionBox
                     bBox={actionBoxBbox}
                     show={this.state.active}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/arrow-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/arrow-decorator.jsx
@@ -103,6 +103,8 @@ Arrow.propTypes = {
     description: PropTypes.string,
     classNameArrow: PropTypes.string,
     classNameArrowHead: PropTypes.string,
+    // This was introduced to place the arrow head in a specific point of the arrow decorator
+    // Was used for client responding and worker init arrows. No longer required.
     arrowHeadPosition: PropTypes.shape({
         x: PropTypes.number,
         y: PropTypes.number,

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client-responder-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client-responder-decorator.jsx
@@ -225,10 +225,6 @@ class ClientResponderDecorator extends React.Component {
                     <ArrowDecorator
                         start={viewState.components.invocation.start}
                         end={viewState.components.invocation.end}
-                        // -5 is reduced roughly for arrow head height
-                        arrowHeadPosition={{
-                            x: (viewState.components.invocation.end.x
-                                + this.context.designer.config.clientLine.arrowGap - 5) }}
                     />
                 </g>
                 {isBreakpoint && this.renderBreakpointIndicator()}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client.jsx
@@ -19,7 +19,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ArrowDecorator from '../decorators/arrow-decorator';
 
 class Client extends React.Component {
 
@@ -124,11 +123,12 @@ class Client extends React.Component {
                 >{bBox.text}</text>
                 <title> {bBox.fullText} </title>
             </g>
-            <ArrowDecorator
-                start={{ x: line.x1, y: invokeLineY }}
-                end={{ x: bBox.arrowLine, y: invokeLineY }}
-                arrowHeadPosition={{ x: (line.x1 + this.context.designer.config.clientLine.arrowGap) }}
-                classNameArrow='client-invocation-arrow'
+            <line
+                x1={line.x1}
+                y1={invokeLineY}
+                x2={bBox.arrowLine}
+                y2={invokeLineY}
+                className='client-invocation-arrow'
             />
         </g>);
     }

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
@@ -216,20 +216,12 @@ class LifeLine extends React.Component {
                     isDefaultWorker={isDefaultWorker}
                 />
             }
-            {TreeUtils.isWorker(this.props.model) &&
-                <g>
-                    <circle
-                        cx={startX}
-                        cy={startY}
-                        r='4'
-                        className={lineClass + ' dot'}
-                    />
-                    <ArrowDecorator
-                        start={{ x: startX - 4, y: startY }}
-                        end={{ x: startX - 4, y: startY }}
-                        classNameArrow={lineClass + 'client-invocation-arrow'}
-                    />
-                </g>
+            {!TreeUtils.isEndpointTypeVariableDef(this.props.model) &&
+                <ArrowDecorator
+                    start={{ x: startX, y: startY }}
+                    end={{ x: startX, y: startY }}
+                    classNameArrow={lineClass + 'client-invocation-arrow'}
+                />
             }
         </g>);
     }

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
@@ -27,6 +27,7 @@ import TreeUtils from './../../../../../model/tree-util';
 import OverlayComponentsRenderingUtil from './../utils/overlay-component-rendering-util';
 import ActionBox from './action-box';
 import ActiveArbiter from './active-arbiter';
+import ArrowDecorator from '../decorators/arrow-decorator';
 
 class LifeLine extends React.Component {
 
@@ -101,7 +102,6 @@ class LifeLine extends React.Component {
         const lineClass = `${this.props.classes.lineClass} unhoverable`;
         const polygonClassTop = this.props.classes.polygonClass;
         const polygonClassBottom = `${this.props.classes.polygonClass} unhoverable`;
-        const centerX = bBox.x + (bBox.w / 2);
         const startSolidLineFrom = this.props.startSolidLineFrom;
         const titleBoxH = DesignerDefaults.lifeLine.head.height;
         const y2 = bBox.h + bBox.y;
@@ -123,7 +123,7 @@ class LifeLine extends React.Component {
         if (this.props.tooltip) {
             tooltip = this.props.tooltip;
         }
-        let modifiedCenterValueForTop = centerX;
+        let modifiedCenterValueForTop = startX;
         const imageX = bBox.x + (DesignerDefaults.iconForTool.width / 4);
         const imageYTop = bBox.y + (DesignerDefaults.iconForTool.height / 4);
         const imageYBottom = y2 - titleBoxH + (DesignerDefaults.iconForTool.height / 4);
@@ -139,6 +139,9 @@ class LifeLine extends React.Component {
                 iconColor = '#6f7b96';
             }
         }
+
+        const startX = bBox.x + (bBox.w / 2);
+        const startY = bBox.y + titleBoxH + this.context.designer.config.statement.height;
         return (<g
             className='life-line-group'
             onMouseOut={this.setActionVisibilityFalse}
@@ -148,17 +151,17 @@ class LifeLine extends React.Component {
             <title> {tooltip} </title>
 
             {!_.isNil(startSolidLineFrom) && <line
-                x1={centerX}
+                x1={startX}
                 y1={dashedY1}
-                x2={centerX}
+                x2={startX}
                 y2={dashedY2}
                 className={lineClass}
                 strokeDasharray='5, 5'
             />}
             <line
-                x1={centerX}
+                x1={startX}
                 y1={solidY1}
-                x2={centerX}
+                x2={startX}
                 y2={solidY2}
                 className={lineClass}
             />
@@ -172,7 +175,7 @@ class LifeLine extends React.Component {
             {this.props.icon &&
             <g onClick={this.handleConnectorProps}>
                 <image
-                    x={centerX - (iconSize / 2)}
+                    x={startX - (iconSize / 2)}
                     y={bBox.y - 25}
                     width={iconSize}
                     height={iconSize}
@@ -188,7 +191,7 @@ class LifeLine extends React.Component {
                 className={lineClass}
             />
             <text
-                x={centerX}
+                x={startX}
                 y={solidY1 - 10}
                 textAnchor='middle'
                 dominantBaseline='central'
@@ -197,7 +200,7 @@ class LifeLine extends React.Component {
                 onClick={e => this.openExpressionEditor(e)}
             >{identifier}</text>
             <text
-                x={centerX}
+                x={startX}
                 y={solidY2 + 10}
                 textAnchor='middle'
                 dominantBaseline='central'
@@ -213,12 +216,21 @@ class LifeLine extends React.Component {
                     isDefaultWorker={isDefaultWorker}
                 />
             }
-            <circle
-                cx={centerX}
-                cy={bBox.y + titleBoxH + this.context.designer.config.statement.height}
-                r='4'
-                className={lineClass + ' dot'}
-            />
+            {TreeUtils.isWorker(this.props.model) &&
+                <g>
+                    <circle
+                        cx={startX}
+                        cy={startY}
+                        r='4'
+                        className={lineClass + ' dot'}
+                    />
+                    <ArrowDecorator
+                        start={{ x: startX - 4, y: startY }}
+                        end={{ x: startX - 4, y: startY }}
+                        classNameArrow={lineClass + 'client-invocation-arrow'}
+                    />
+                </g>
+            }
         </g>);
     }
 }

--- a/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/positioning-util.js
@@ -56,9 +56,8 @@ class PositioningUtil {
 
             // Move the x cordinates to centre align the action invocation statement
             viewState.components['statement-box'].x -= (this.config.actionInvocationStatement.width / 2);
-            viewState.bBox.x -= (this.config.actionInvocationStatement.width / 2);
 
-            arrowStartBBox.x = viewState.bBox.x + viewState.bBox.w;
+            arrowStartBBox.x = viewState.bBox.x;
             arrowStartBBox.y = viewState.components['statement-box'].y
                                 + this.config.actionInvocationStatement.textHeight;
 
@@ -72,7 +71,9 @@ class PositioningUtil {
                     end: undefined,
                 };
                 viewState.components.invocation.start = arrowStartBBox;
-                arrowEndBBox.x = endpoint.viewState.bBox.x + (endpoint.viewState.bBox.w / 2);
+                arrowEndBBox.x = endpoint.viewState.bBox.x
+                                + (endpoint.viewState.bBox.w / 2)
+                                - (this.config.actionInvocationStatement.width / 2);
                 arrowEndBBox.y = arrowStartBBox.y;
                 viewState.components.invocation.end = arrowEndBBox;
                 if (endpoint.viewState.showOverlayContainer) {

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1650,8 +1650,6 @@ class SizingUtil {
         // This function gets called by statements containing action invocation expressions
         if (TreeUtil.statementIsInvocation(node)) {
             const viewState = node.viewState;
-            viewState.bBox.w = this.config.actionInvocationStatement.width;
-            viewState.components['statement-box'].w = this.config.actionInvocationStatement.width;
             viewState.bBox.h = this.config.actionInvocationStatement.height;
             viewState.components['statement-box'].h = this.config.actionInvocationStatement.height;
             viewState.alias = 'ActionInvocationNode';

--- a/modules/web/src/plugins/ballerina/tool-palette/item-provider/worker-tools.js
+++ b/modules/web/src/plugins/ballerina/tool-palette/item-provider/worker-tools.js
@@ -34,7 +34,7 @@ const tools = [
         title: 'While',
         nodeFactoryMethod: DefaultNodeFactory.createWhile,
         description: 'Provide a way to execute a series of statements as long as a boolean expression is met',
-    }, /*
+    },
     {
         id: 'try-catch',
         name: 'Try-Catch',
@@ -43,7 +43,7 @@ const tools = [
         nodeFactoryMethod: DefaultNodeFactory.createTry,
         description: 'Handle the exception by the block after the catch,'
         + ' if any exception occurs while executing the first block of statements',
-    }, */
+    },
     {
         id: 'WorkerInvocation',
         name: 'Send',
@@ -59,7 +59,7 @@ const tools = [
         title: 'Worker Receive',
         nodeFactoryMethod: DefaultNodeFactory.createWorkerReceive,
         description: 'Provide a way to receive the reply from a worker',
-    }, /*
+    },
     {
         id: 'Transaction',
         name: 'Transaction',
@@ -68,7 +68,7 @@ const tools = [
         nodeFactoryMethod: DefaultNodeFactory.createTransaction,
         description: 'Series of data manipulation statements that must either'
         + ' fully complete or fully fail, leaving the system in a consistent state',
-    },
+    }, /*
     {
         id: 'Fork',
         name: 'Fork',


### PR DESCRIPTION
This PR contains following fixes/improvements : 
- Add arrowhead to all workers to represent activation
![image](https://user-images.githubusercontent.com/1029806/34665405-0e5e4210-f486-11e7-8783-361bddf6b3e7.png)
- Change action invocation representation to show timeline on endpoint instead of worker
![image](https://user-images.githubusercontent.com/1029806/34664495-2da74f62-f482-11e7-9743-63b4c5bd70df.png)
- Issue in sizing of action invocations in flow mode
Before : 
![image](https://user-images.githubusercontent.com/1029806/34664593-a7b931f8-f482-11e7-90fc-e13a05ea7072.png)
Now : 
![image](https://user-images.githubusercontent.com/1029806/34665088-fbedcda4-f484-11e7-9a80-36efd2f7a274.png)
- Change client responder arrows to have arrow head on client line
![image](https://user-images.githubusercontent.com/1029806/34665822-b80d255a-f487-11e7-87d7-60c83defd35f.png)
- Show client responder arrows in flow view
- Show transaction and try statements in lifeline + 



  
  
  