### PR TITLE
Design view improvements/fixes

### DIFF
--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -1331,6 +1331,13 @@
         font-style: italic;
         font-weight: bolder;
     }
+
+    .flowchart-title-text {
+        text-anchor: middle;
+        dominant-baseline: text-after-edge;
+        font-style: italic;
+        font-weight: 500;
+    }
     
     /*//////////////////////////////////////////////////*/
     /** Service container related styles | Start -> **/

--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -942,10 +942,9 @@
         fill: $default-worker-lifeline-color;
         stroke: $default-worker-lifeline-color;
     }
-    .flowchart-dash-line{
-        stroke: #ffffff;
+    .flowchart-separator-line{
+        stroke: #fff;
         stroke-width: 2;
-        stroke-dasharray: 3,2;
     }
     
     .struct-content-operations-wrapper{

--- a/modules/web/scss/themes/dark.scss
+++ b/modules/web/scss/themes/dark.scss
@@ -69,7 +69,7 @@ $modal-btn-primary-hover-color: #fff;
 
 $primary-line-bgcolor: #666769;
 $default-worker-lifeline-color: #0070af;
-$worker-lifeline-color: #0b91dc;
+$worker-lifeline-color: #0070af;
 $connector-lifeline-color: #26A69A;
 
 $annotation-wrapper-bgcolor: #eee;

--- a/modules/web/scss/themes/default.scss
+++ b/modules/web/scss/themes/default.scss
@@ -69,7 +69,7 @@ $modal-btn-primary-hover-color: #fff;
 
 $primary-line-bgcolor: #666769;
 $default-worker-lifeline-color: #0070af;
-$worker-lifeline-color: #0b91dc;
+$worker-lifeline-color: #0070af;
 $connector-lifeline-color: #26A69A;
 
 $annotation-wrapper-bgcolor: #eee;

--- a/modules/web/scss/themes/light.scss
+++ b/modules/web/scss/themes/light.scss
@@ -69,7 +69,7 @@ $modal-btn-primary-hover-color: #fff;
 
 $primary-line-bgcolor: #666769;
 $default-worker-lifeline-color: #0070af;
-$worker-lifeline-color: #0b91dc;
+$worker-lifeline-color: #0070af;
 $connector-lifeline-color: #26A69A;
     
 $annotation-wrapper-bgcolor: #eee;

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/arrow-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/arrow-decorator.jsx
@@ -79,7 +79,7 @@ class Arrow extends React.Component {
                     className={className}
                 />
                 <polygon
-                    points={`-${arrowSize},-${arrowSize} 0,0 -${arrowSize},${arrowSize}`}
+                    points={`-${arrowSize},-${arrowSize * (7 / 10)} 0,0 -${arrowSize},${arrowSize * (7 / 10)}`}
                     transform={`translate(${arrowHeadX}, ${arrowHeadY})
                                 rotate(${this.getArrowAngle(start, end)}, 0, 0)`}
                     className={classNameArrowHead}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client-responder-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/client-responder-decorator.jsx
@@ -196,12 +196,6 @@ class ClientResponderDecorator extends React.Component {
                     enableCenterOverlayLine
                 />
                 <g>
-                    <circle
-                        cx={statementBox.x}
-                        cy={statementBox.y + this.context.designer.config.actionInvocationStatement.textHeight}
-                        r='4'
-                        className={'worker-life-line dot'}
-                    />
                     <text
                         x={viewState.components.invocation.end.x
                             + this.context.designer.config.statement.gutter.h}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
@@ -28,6 +28,7 @@ import ActiveArbiter from '../decorators/active-arbiter';
 import Breakpoint from '../decorators/breakpoint';
 import { getComponentForNodeArray } from './../../../../diagram-util';
 import ElseStatementDecorator from './else-statement-decorator';
+import ArrowDecorator from '../decorators/arrow-decorator';
 
 /**
  * Wraps other UI elements and provide box with a heading.
@@ -283,8 +284,14 @@ class IfStatementDecorator extends React.Component {
                 }}
             >
                 <polyline
-                    points={`${p3X},${p3Y} ${p4X},${p4Y} ${p5X},${p5Y} ${p6X}, ${p6Y}`}
+                    points={`${p3X},${p3Y} ${p4X},${p4Y} ${p5X},${p5Y}`}
                     className='flowchart-background-empty-rect'
+                />
+                <ArrowDecorator
+                    start={{ x: p5X, y: p5Y }}
+                    end={{ x: p6X, y: p6Y }}
+                    classNameArrow='flowchart-action-arrow'
+                    classNameArrowHead='flowchart-action-arrow-head'
                 />
                 <polyline
                     points={`${p2X},${p2Y} ${p8X},${p8Y} ${p3X},${p3Y} ${p9X}, ${p9Y} ${p2X},${p2Y}`}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
@@ -258,8 +258,8 @@ class IfStatementDecorator extends React.Component {
         const p12X = p8X;
         const p12Y = p8Y + this.context.designer.config.flowChartControlStatement.heading.flowPathHeight;
 
-        this.conditionBox = new SimpleBBox(p1X, (p2Y - (this.context.designer.config.statement.height / 2)),
-            bBox.w, this.context.designer.config.statement.height);
+        this.conditionBox = new SimpleBBox(p2X, (p2Y - (this.context.designer.config.statement.height / 2)),
+            statementBBox.w, this.context.designer.config.statement.height);
 
         const actionBoxBbox = new SimpleBBox();
         actionBoxBbox.w = (3 * designer.config.actionBox.width) / 4;

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/if-statement-decorator.jsx
@@ -287,12 +287,28 @@ class IfStatementDecorator extends React.Component {
                     points={`${p3X},${p3Y} ${p4X},${p4Y} ${p5X},${p5Y}`}
                     className='flowchart-background-empty-rect'
                 />
-                <ArrowDecorator
-                    start={{ x: p5X, y: p5Y }}
-                    end={{ x: p6X, y: p6Y }}
-                    classNameArrow='flowchart-action-arrow'
-                    classNameArrowHead='flowchart-action-arrow-head'
-                />
+                {(() => {
+                    if (viewState.isLastPathLine) {
+                        return (
+                            <line
+                                x1={p5X}
+                                y1={p5Y}
+                                x2={p6X}
+                                y2={p6Y}
+                                className='flowchart-background-empty-rect'
+                            />
+                        );
+                    } else {
+                        return (
+                            <ArrowDecorator
+                                start={{ x: p5X, y: p5Y }}
+                                end={{ x: p6X, y: p6Y }}
+                                classNameArrow='flowchart-action-arrow'
+                                classNameArrowHead='flowchart-action-arrow-head'
+                            />
+                        );
+                    }
+                })()}
                 <polyline
                     points={`${p2X},${p2Y} ${p8X},${p8Y} ${p3X},${p3Y} ${p9X}, ${p9Y} ${p2X},${p2Y}`}
                     className={statementRectClass}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/while-statement-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/while-statement-decorator.jsx
@@ -262,8 +262,8 @@ class WhileStatementDecorator extends React.Component {
         const p12X = p8X;
         const p12Y = p8Y + this.context.designer.config.flowChartControlStatement.heading.flowPathHeight;
 
-        this.conditionBox = new SimpleBBox(p1X, (p2Y - (this.context.designer.config.statement.height / 2)),
-            bBox.w, this.context.designer.config.statement.height);
+        this.conditionBox = new SimpleBBox(p2X, (p2Y - (this.context.designer.config.statement.height / 2)),
+            statementBBox.w, this.context.designer.config.statement.height);
 
         const actionBoxBbox = new SimpleBBox();
         actionBoxBbox.w = (3 * designer.config.actionBox.width) / 4;

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/while-statement-decorator.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/while-statement-decorator.jsx
@@ -291,7 +291,7 @@ class WhileStatementDecorator extends React.Component {
                     className='flowchart-background-empty-rect'
                 />
                 <ArrowDecorator
-                    start={{ x: p11X, y: p11Y }}
+                    start={{ x: p11X - 0.5, y: p11Y }}
                     end={{ x: p2X, y: p2Y }}
                     classNameArrow='flowchart-action-arrow'
                     classNameArrowHead='flowchart-action-arrow-head'
@@ -306,10 +306,10 @@ class WhileStatementDecorator extends React.Component {
                 />
                 <line
                     x1={p10X}
-                    y1={p10Y}
+                    y1={p10Y + 0.5}
                     x2={p6X}
-                    y2={p6Y}
-                    className='flowchart-dash-line'
+                    y2={p6Y - 0.5}
+                    className='flowchart-separator-line'
                 />
                 {expression &&
                     <text

--- a/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/worker-node.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/worker-node.jsx
@@ -98,7 +98,7 @@ class WorkerNode extends React.Component {
                     editorOptions={editorOptions}
                     classes={classes}
                     icon={ImageUtil.getSVGIconString('tool-icons/worker')}
-                    iconColor='#0380c6'
+                    iconColor='#0070af'
                     onDelete={this.onDelete}
                 />
                 {blockNode}

--- a/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/designer-defaults.js
@@ -182,7 +182,7 @@ export const flowChartControlStatement = {
         height: 100,
     },
     padding: {
-        left: statement.padding.left,
+        left: (2 * statement.gutter.h),
         top: (statement.height / 2),
         bottom: (statement.height / 2),
     },

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1479,7 +1479,6 @@ class SizingUtil {
         viewState.components['statement-box'].w = bodyWidth;
         viewState.bBox.h = viewState.components['statement-box'].h
                             + viewState.components['drop-zone'].h
-                            + this.config.statement.gutter.h
                             + components['block-header'].h;
         viewState.bBox.w = bodyWidth;
 
@@ -1505,6 +1504,18 @@ class SizingUtil {
         }
         node.viewState.bBox.h = nodeHeight;
         node.viewState.bBox.w = nodeWidth;
+
+        // if the statement right before if statement end is one with
+        // a separator, arrow must not be drawn to it. It should only be a line.
+        // e.g. :
+        // if (true) {
+        //     while (true) {
+        //     }
+        // }
+        if ((node.body.statements.length > 0 && TreeUtil.isWhile(_.last(node.body.statements)))
+                && (!elseStmt || (TreeUtil.isBlock(elseStmt) && elseStmt.statements.length === 0))) {
+            node.viewState.isLastPathLine = true;
+        }
     }
 
     /**

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1484,6 +1484,16 @@ class SizingUtil {
 
         components['block-header'].setOpaque(true);
 
+        // calculate left margin from the lifeline centre
+        let leftMargin = this.calcLeftMargin(node.body.statements);
+        leftMargin = (leftMargin === 0) ? this.config.flowChartControlStatement.gap.left
+                                        // since there is no left expansion for if,
+                                        // we take the left margin as it is
+                                        : leftMargin;
+        viewState.components['left-margin'] = {
+            w: leftMargin,
+        };
+
         // for compound statement like if , while we need to render condition expression
         // we will calculate the width of the expression and adjust the block statement
         if (expression) {
@@ -1763,6 +1773,8 @@ class SizingUtil {
         // calculate left margin from the lifeline centre
         let leftMargin = this.calcLeftMargin(node.body.statements);
         leftMargin = (leftMargin === 0) ? this.config.flowChartControlStatement.gap.left
+                                        // since there is a left expansion for while when nested,
+                                        // add a left padding
                                         : (leftMargin + this.config.flowChartControlStatement.padding.left);
         viewState.components['left-margin'] = {
             w: leftMargin,

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1745,8 +1745,7 @@ class SizingUtil {
         viewState.components['statement-box'].w = bodyWidth;
         viewState.bBox.h = viewState.components['statement-box'].h
                             + viewState.components['drop-zone'].h
-                            + this.config.flowChartControlStatement.gutter.h // for the lower dashed line
-                            + this.config.statement.gutter.h
+                            + this.config.flowChartControlStatement.gutter.h // for the lower separator line
                             + viewState.components['block-header'].h;
         viewState.bBox.w = bodyWidth;
 

--- a/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
+++ b/modules/web/src/plugins/ballerina/diagram/views/default/sizing-util.js
@@ -1801,7 +1801,9 @@ class SizingUtil {
         let leftMargin = 0;
         nodes.forEach((node) => {
             if (node.viewState.components['left-margin']) {
-                leftMargin += node.viewState.components['left-margin'].w;
+                if (node.viewState.components['left-margin'].w > leftMargin) {
+                    leftMargin = node.viewState.components['left-margin'].w;
+                }
             }
         });
         return leftMargin;


### PR DESCRIPTION
This PR contains : 
- Improvements to nested while and if-else scenarios
<img width="419" alt="image" src="https://user-images.githubusercontent.com/1029806/34763612-cacc1a9e-f611-11e7-8ed4-b60edbee99be.png">
<img width="469" alt="image" src="https://user-images.githubusercontent.com/1029806/34772060-cfe92060-f62c-11e7-8d30-0910781e70f7.png">
- Improvements to client responder
- Add check to draw arrow or not based on if-else statements. If the last statement above the separator of if is one with a gap (while), do not draw the arrow.
Before:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/1029806/34772009-98cd7950-f62c-11e7-8552-4589cc72fcd8.png">
Now:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/1029806/34772013-9f7eacec-f62c-11e7-9146-460f71bfe490.png">
- Fix wrong color in lifeline text and line
- Fix issue in extra long expression editor in conditions
  