### PR TITLE
Moved split view inside the ballerina file editor tab.

### DIFF
--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -3980,21 +3980,19 @@
         position: absolute;
         height: 100%;
         width: 100%;
-        background-color: rgba(60, 60, 60, 0.5);
+        background-color: rgba(60, 60, 60, 0.0);
         .error-list {
-            border-left: 5px solid #910a0a;
             position: relative;
             text-align: left;
             padding: 10px;
-            left: 20%;
-            top: 20%;
-            width: 60%;
-            background-color: rgba(60, 60, 60, 1);
-            color: white;
+            width:400px;
+            margin: auto;
+            top: 20px;
+            background-color: #d8d8d8;
             .list-heading {
                 text-align: center;
                 font-size: 16px;
-                margin-bottom: 15px;
+                color:#CC0000;
             }
         }
     }
@@ -4424,4 +4422,10 @@
   
   .grid-background {
     height: 100%;
+  }
+
+  .design-view-disabled {
+      .button-background{
+          color: #a3a3a3 !important;
+      }
   }

--- a/modules/web/scss/modules/ballerina-editor.scss
+++ b/modules/web/scss/modules/ballerina-editor.scss
@@ -2716,7 +2716,6 @@
     }
     
     .SplitPane .vertical  {
-        background-color: #FFF;
     }
     
     .swagger-ui h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
@@ -2743,7 +2742,7 @@
     }
     
     .SplitPane .vertical {
-        overflow: auto;
+        overflow: hidden;
     }
     
     .swaggerEditor .SplitPane {

--- a/modules/web/src/core/editor/views/EditorTabs.jsx
+++ b/modules/web/src/core/editor/views/EditorTabs.jsx
@@ -71,7 +71,7 @@ class EditorTabs extends View {
         };
 
         // Binding commands.
-        props.editorPlugin.appContext.command.on('show-split-view', () => {
+        props.editorPlugin.appContext.command.on('show-preview-panel', () => {
             this.setPreviewPanelState(true);
         });
 
@@ -219,9 +219,9 @@ class EditorTabs extends View {
                             autoHide // Hide delay in ms
                             autoHideTimeout={1000}
                         >
-                                <editor.component
-                                    {...finalProps}
-                                />
+                            <editor.component
+                                {...finalProps}
+                            />
                         </Scrollbars>
                     </ErrorBoundary>
                 </TabPane>

--- a/modules/web/src/plugins/ballerina/diagram/diagram.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/diagram.jsx
@@ -170,6 +170,9 @@ class Diagram extends React.Component {
 
         controllers = _.merge(controllers, overlayComponents);
 
+        if (this.props.disabled) {
+            controllers = [];
+        }
 
         const tln = (this.props.model.getTopLevelNodes()) ? this.props.model.getTopLevelNodes() : [];
         const children = getComponentForNodeArray(tln, this.props.mode);
@@ -180,6 +183,7 @@ class Diagram extends React.Component {
             dropTarget={this.props.model}
             bBox={viewState.bBox}
             overlayComponents={controllers}
+            disabled={this.props.disabled}
         >
             { children }
             <TopLevelNodes model={this.props.model} />
@@ -192,6 +196,7 @@ Diagram.propTypes = {
     mode: PropTypes.string,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
+    disabled: PropTypes.bool.isRequired,
 };
 
 Diagram.contextTypes = {
@@ -212,6 +217,7 @@ Diagram.childContextTypes = {
 
 Diagram.defaultProps = {
     mode: 'default',
+    disabled: false,
 };
 
 export default Diagram;

--- a/modules/web/src/plugins/ballerina/diagram/diagram.jsx
+++ b/modules/web/src/plugins/ballerina/diagram/diagram.jsx
@@ -170,10 +170,6 @@ class Diagram extends React.Component {
 
         controllers = _.merge(controllers, overlayComponents);
 
-        if (this.props.disabled) {
-            controllers = [];
-        }
-
         const tln = (this.props.model.getTopLevelNodes()) ? this.props.model.getTopLevelNodes() : [];
         const children = getComponentForNodeArray(tln, this.props.mode);
 

--- a/modules/web/src/plugins/ballerina/model/default-node-factory.js
+++ b/modules/web/src/plugins/ballerina/model/default-node-factory.js
@@ -18,7 +18,6 @@
 import _ from 'lodash';
 import FragmentUtils from '../utils/fragment-utils';
 import TreeBuilder from './tree-builder';
-import TreeUtils from './tree-util';
 import Environment from '../env/environment';
 import DefaultNodes from './default-nodes';
 import ConnectorHelper from './../env/helpers/connector-helper';
@@ -61,35 +60,30 @@ class DefaultNodeFactory {
 
     createHTTPServiceDef() {
         const node = getStaticDefaultNode('createHTTPServiceDef');
-        node.viewState.shouldShowConnectorPropertyWindow = true;
         node.setFullPackageName('ballerina.net.http');
         return node;
     }
 
     createWSServiceDef() {
         const node = getStaticDefaultNode('createWSServiceDef');
-        node.viewState.shouldShowConnectorPropertyWindow = true;
         node.setFullPackageName('ballerina.net.ws');
         return node;
     }
 
     createJMSServiceDef() {
         const node = getStaticDefaultNode('createJMSServiceDef');
-        node.viewState.shouldShowConnectorPropertyWindow = true;
         node.setFullPackageName('ballerina.net.jms');
         return node;
     }
 
     createFSServiceDef() {
         const node = getStaticDefaultNode('createFSServiceDef');
-        node.viewState.shouldShowConnectorPropertyWindow = true;
         node.setFullPackageName('ballerina.net.fs');
         return node;
     }
 
     createFTPServiceDef() {
         const node = getStaticDefaultNode('createFTPServiceDef');
-        node.viewState.shouldShowConnectorPropertyWindow = true;
         node.setFullPackageName('ballerina.net.ftp');
         return node;
     }
@@ -153,11 +147,6 @@ class DefaultNodeFactory {
 
     createAssignmentStmt() {
         const node = getStaticDefaultNode('createAssignmentStmt');
-        // Check if the node is a ConnectorDeclaration
-        if (TreeUtils.isEndpointTypeVariableDef(node)) {
-            node.viewState.showOverlayContainer = true;
-            return node;
-        }
         return node;
     }
 
@@ -167,11 +156,6 @@ class DefaultNodeFactory {
 
     createVarDefStmt() {
         const node = getStaticDefaultNode('createVarDefStmt');
-        // Check if the node is a ConnectorDeclaration
-        if (TreeUtils.isEndpointTypeVariableDef(node)) {
-            node.viewState.showOverlayContainer = true;
-            return node;
-        }
         return node;
     }
 
@@ -253,13 +237,14 @@ class DefaultNodeFactory {
     }
 
     createConnectorDeclaration(args) {
-        const node = getNodeForFragment(FragmentUtils.createStatementFragment('http:HttpClient endpoint1 = create http:HttpClient("",{});'));
+        const node = getNodeForFragment(
+            FragmentUtils.createStatementFragment('http:HttpClient endpoint1 = create http:HttpClient("",{});'));
         const { connector, packageName, fullPackageName } = args;
 
         // Iterate through the params
         const parameters = [];
         if (connector.getParams()) {
-            const connectorParams = connector.getParams().map((param) => {
+            connector.getParams().forEach((param) => {
                 let defaultValue = Environment.getDefaultValue(param.type);
                 if (defaultValue === undefined) {
                     // Check if its a struct or enum
@@ -283,10 +268,11 @@ class DefaultNodeFactory {
         const pkgStr = packageName !== 'Current Package' ? `${packageName}` : '';
         node.getVariable().getTypeNode().getTypeName().setValue(connector.getName());
         node.getVariable().getTypeNode().getPackageAlias().setValue(pkgStr);
-        node.getVariable().getInitialExpression().getConnectorType().getPackageAlias().setValue(pkgStr);
-        node.getVariable().getInitialExpression().getConnectorType().getTypeName().setValue(connector.getName());
+        node.getVariable().getInitialExpression().getConnectorType().getPackageAlias()
+            .setValue(pkgStr);
+        node.getVariable().getInitialExpression().getConnectorType().getTypeName()
+            .setValue(connector.getName());
         node.getVariable().getInitialExpression().setFullPackageName(fullPackageName);
-        node.viewState.showOverlayContainer = true;
         return node;
     }
 
@@ -302,7 +288,7 @@ class DefaultNodeFactory {
         const parameters = [];
         const pkgStr = packageName !== 'Current Package' ? packageName.split(/[.]+/).pop() : '';
         if (connector && connector.getParams()) {
-            const connectorParams = connector.getParams().map((param) => {
+            connector.getParams().forEach((param) => {
                 let defaultValue = Environment.getDefaultValue(param.type);
                 if (defaultValue === undefined) {
                 // Check if its a struct or enum
@@ -322,18 +308,20 @@ class DefaultNodeFactory {
                 parameters.push(paramNode.getVariable().getInitialExpression());
             });
             node.getVariable().getInitialExpression().setExpressions(parameters);
-            node.getVariable().getTypeNode().getConstraint().getTypeName().setValue(connector.getName());
-            node.getVariable().getTypeNode().getConstraint().getPackageAlias().setValue(pkgStr);
-            node.getVariable().getInitialExpression().getConnectorType().getPackageAlias().setValue(pkgStr);
-            node.getVariable().getInitialExpression().getConnectorType().getTypeName().setValue(connector.getName());
+            node.getVariable().getTypeNode().getConstraint().getTypeName()
+                .setValue(connector.getName());
+            node.getVariable().getTypeNode().getConstraint().getPackageAlias()
+                .setValue(pkgStr);
+            node.getVariable().getInitialExpression().getConnectorType().getPackageAlias()
+                .setValue(pkgStr);
+            node.getVariable().getInitialExpression().getConnectorType().getTypeName()
+                .setValue(connector.getName());
             node.getVariable().getInitialExpression().setFullPackageName(fullPackageName);
         }
-        node.viewState.showOverlayContainer = true;
         return node;
     }
 
     createConnectorActionInvocationAssignmentStatement(args) {
-        let node;
         let stmtString = '';
         const { action, packageName, fullPackageName } = args;
 
@@ -342,7 +330,7 @@ class DefaultNodeFactory {
         }
         stmtString += 'endpoint1.action1();';
 
-        node = getNodeForFragment(FragmentUtils.createStatementFragment(stmtString));
+        const node = getNodeForFragment(FragmentUtils.createStatementFragment(stmtString));
 
         if (action && action.getParameters().length > 0) {
             const parameters = action.getParameters().map((param) => {
@@ -377,7 +365,6 @@ class DefaultNodeFactory {
     }
 
     createFunctionInvocationStatement(args) {
-        let node;
         let stmtString = '';
 
         const { functionDef, packageName, fullPackageName } = args;
@@ -392,7 +379,7 @@ class DefaultNodeFactory {
             stmtString += 'function1();';
         }
 
-        node = getNodeForFragment(FragmentUtils.createStatementFragment(stmtString));
+        const node = getNodeForFragment(FragmentUtils.createStatementFragment(stmtString));
 
         if (functionDef.getParameters().length > 0) {
             const parameters = functionDef.getParameters().map((param) => {

--- a/modules/web/src/plugins/ballerina/plugin.js
+++ b/modules/web/src/plugins/ballerina/plugin.js
@@ -19,26 +19,25 @@ import _ from 'lodash';
 import log from 'log';
 import Plugin from 'core/plugin/plugin';
 import { listen } from 'vscode-ws-jsonrpc';
+import { setTimeout } from 'timers';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import { parseFile, getPathSeperator, getServiceEndpoint } from 'api-client/api-client';
 import { CONTRIBUTIONS } from 'core/plugin/constants';
 import { REGIONS, COMMANDS as LAYOUT_COMMANDS } from 'core/layout/constants';
 import { EVENTS as WORKSPACE_EVENTS, COMMANDS as WORKSPACE_CMDS } from 'core/workspace/constants';
 import { createOrUpdate, move } from 'core/workspace/fs-util';
-import SourceEditor from 'plugins/ballerina/views/source-editor';
 import { CLASSES } from 'plugins/ballerina/views/constants';
 import Document from 'plugins/ballerina/docerina/document.jsx';
 import Editor from './views/editor-wrapper';
 import { PLUGIN_ID, EDITOR_ID, DOC_VIEW_ID, COMMANDS as COMMAND_IDS, TOOLS as TOOL_IDS,
-            DIALOGS as DIALOG_IDS, EVENTS, VIEWS as VIEW_IDS } from './constants';
+            DIALOGS as DIALOG_IDS, EVENTS } from './constants';
 import OpenProgramDirConfirmDialog from './dialogs/OpenProgramDirConfirmDialog';
 import FixPackageNameOrPathConfirmDialog from './dialogs/FixPackageNameOrPathConfirmDialog';
 import { getLangServerClientInstance } from './langserver/lang-server-client-controller';
-import ToolPaletteView from './tool-palette/tool-palette-view';
 import { isInCorrectPath, getCorrectPackageForPath, getCorrectPathForPackage } from './utils/program-dir-utils';
 import TreeBuilder from './model/tree-builder';
 import FragmentUtils from './utils/fragment-utils';
-import { setTimeout } from 'timers';
+
 
 /**
  * Plugin for Ballerina Lang
@@ -127,15 +126,6 @@ class BallerinaPlugin extends Plugin {
                         return {
                             ballerinaPlugin: this,
                         };
-                    },
-                    previewView: {
-                        component: SourceEditor,
-                        customPropsProvider: () => {
-                            return {
-                                ballerinaPlugin: this,
-                                parseFailed: false,
-                            };
-                        },
                     },
                     tabTitleClass: CLASSES.TAB_TITLE.DESIGN_VIEW,
                     newFileContentProvider: (fileFullPath) => {

--- a/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -761,31 +761,6 @@ class BallerinaFileEditor extends React.Component {
                     transitionEnterTimeout={300}
                     transitionLeaveTimeout={300}
                 >
-                    {this.props.isPreviewViewEnabled && !_.isEmpty(this.state.syntaxErrors) &&
-                        <div className='syntax-error-overlay'>
-                            <div className='error-list'>
-                                <div className='list-heading'>
-                                    Cannot update design view due to below syntax errors.
-                                </div>
-                                <Scrollbars
-                                    autoHeight
-                                    autoHeightMax={400}
-                                    autoHide
-                                    autoHideTimeout={1000}
-                                >
-                                    <ul className='errors'>
-                                        {this.state.syntaxErrors.map(({ row, column, text }) => {
-                                            return (
-                                                <li>
-                                                    {`${text} at Line:${row}:${column}`}
-                                                </li>
-                                            );
-                                        })}
-                                    </ul>
-                                </Scrollbars>
-                            </div>
-                        </div>
-                    }
                     {showLoadingOverlay &&
                         <div className='bal-file-editor-loading-container'>
                             <div id='parse-pending-loader'>
@@ -804,7 +779,19 @@ class BallerinaFileEditor extends React.Component {
                                         defaultSize={(this.props.width / 2)}
                                         onChange={this.handleSplitChange}
                                     >
-                                        {designView}
+                                        <div>
+                                            {this.state.activeView === SPLIT_VIEW
+                                                && !_.isEmpty(this.state.syntaxErrors) &&
+                                                <div className='syntax-error-overlay'>
+                                                    <div className='error-list'>
+                                                        <div className='list-heading'>
+                                                            Cannot update design view due to syntax errors.
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            }
+                                            {designView}
+                                        </div>
                                         {sourceView}
                                     </SplitPane>
                                 </div>

--- a/modules/web/src/plugins/ballerina/views/constants.js
+++ b/modules/web/src/plugins/ballerina/views/constants.js
@@ -19,6 +19,7 @@
 
 export const DESIGN_VIEW = 'DESIGN_VIEW';
 export const SOURCE_VIEW = 'SOURCE_VIEW';
+export const SPLIT_VIEW = 'SPLIT_VIEW';
 export const SWAGGER_VIEW = 'SWAGGER_VIEW';
 export const FILE_AST_PROPERTY = 'ast';
 

--- a/modules/web/src/plugins/ballerina/views/design-view.jsx
+++ b/modules/web/src/plugins/ballerina/views/design-view.jsx
@@ -162,8 +162,13 @@ class DesignView extends React.Component {
 
         const shouldShowTransform = isTransformActive && activeTransformModel;
 
+        const disabled = (this.props.disabled) ? 'design-view-disabled' : '';
+
         return (
-            <div className='design-view-container' style={{ display: this.props.show ? 'block' : 'none' }}>
+            <div
+                className={`design-view-container ${disabled}`}
+                style={{ display: this.props.show ? 'block' : 'none' }}
+            >
                 <div className='outerCanvasDiv'>
                     <DragLayer />
                     <Scrollbars

--- a/modules/web/src/plugins/ballerina/views/design-view.jsx
+++ b/modules/web/src/plugins/ballerina/views/design-view.jsx
@@ -18,7 +18,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import cn from 'classnames';
 import { Scrollbars } from 'react-custom-scrollbars';
 import BallerinaDiagram from 'plugins/ballerina/diagram/diagram';
 import TransformerExpanded from 'plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded';
@@ -186,6 +185,7 @@ class DesignView extends React.Component {
                                         mode={this.state.mode}
                                         width={this.props.width - TOOL_PALETTE_WIDTH}
                                         height={this.props.height}
+                                        disabled={this.props.disabled}
                                     />
                                 }
                             </div>
@@ -202,44 +202,6 @@ class DesignView extends React.Component {
                     }
                 </div>
                 <div className='tool-palette-container' ref={this.setToolPaletteContainer} />
-                <div className={cn('bottom-right-controls-container', { hide: this.context.isPreviewViewEnabled })}>
-                    <div
-                        className='view-source-btn btn-icon'
-                        onClick={() => {
-                            this.context.editor.setActiveView('SOURCE_VIEW');
-                        }}
-                    >
-                        <div className='bottom-label-icon-wrapper'>
-                            <i className='fw fw-code-view fw-inverse' />
-                        </div>
-                        <div
-                            className='bottom-view-label'
-                            onClick={() => {
-                                this.context.editor.setActiveView('SOURCE_VIEW');
-                            }}
-                        >
-                            Source View
-                        </div>
-                    </div>
-                    <div
-                        className='view-split-view-btn btn-icon'
-                        onClick={() => {
-                            this.props.commandProxy.dispatch('show-split-view', true);
-                        }}
-                    >
-                        <div className='bottom-label-icon-wrapper'>
-                            <i className='fw fw-code fw-inverse' />
-                        </div>
-                        <div
-                            className='bottom-view-label'
-                            onClick={() => {
-                                this.props.commandProxy.dispatch('show-split-view', true);
-                            }}
-                        >
-                            Split View
-                        </div>
-                    </div>
-                </div>
             </div>
         );
     }
@@ -256,11 +218,13 @@ DesignView.propTypes = {
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
     panelResizeInProgress: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool.isRequired,
 };
 
 DesignView.defaultProps = {
     show: true,
     model: undefined,
+    disabled: false,
 };
 
 DesignView.contextTypes = {

--- a/modules/web/src/plugins/ballerina/views/source-view.jsx
+++ b/modules/web/src/plugins/ballerina/views/source-view.jsx
@@ -175,31 +175,6 @@ class SourceView extends React.Component {
                             }
                         }
                     >
-                        <div className={classNames('view-design-btn btn-icon',
-                                    { target: this.state.displayErrorList })}
-                        >
-                            <div className='bottom-label-icon-wrapper'>
-                                <i className='fw fw-design-view fw-inverse' />
-                            </div>
-                            <div
-                                className='bottom-view-label'
-                                ref={(ref) => {
-                                    this.errorListPopoverTarget = ref;
-                                }}
-                            >
-                                Design View
-                            </div>
-                            {hasSyntaxErrors && this.context.isTabActive() &&
-                                <Overlay
-                                    show={this.state.displayErrorList}
-                                    container={this}
-                                    target={this.errorListPopoverTarget}
-                                    placement='top'
-                                >
-                                    {errorListPopover}
-                                </Overlay>
-                            }
-                        </div>
                         {hasSyntaxErrors && !this.state.displayErrorList &&
                             <CSSTransitionGroup
                                 transitionName='error-count-badge'

--- a/modules/web/src/plugins/ballerina/views/view-button.jsx
+++ b/modules/web/src/plugins/ballerina/views/view-button.jsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * utton to switch views
+ */
+class ViewButton extends React.Component {
+
+    render() {
+        return (
+            <div
+                className='view-split-view-btn btn-icon'
+                onClick={this.props.onClick}
+            >
+                <div className='bottom-label-icon-wrapper'>
+                    <i className={`fw fw-${this.props.icon} fw-inverse`} />
+                </div>
+                <div
+                    className='bottom-view-label'
+                    onClick={this.props.onClick}
+                >
+                    {this.props.label}
+                </div>
+            </div>
+        );
+    }
+
+}
+
+ViewButton.propTypes = {
+    onClick: PropTypes.func.isRequired,
+    label: PropTypes.string,
+    icon: PropTypes.string.isRequired,
+};
+
+ViewButton.defaultProps = {
+    label: '',
+};
+
+export default ViewButton;


### PR DESCRIPTION
This PR include the following changes. 
* Prevent options dialog popping out with node additions.
￼* Implement split view within ballerina file editor.
* Made the parser error display subtle. 

New Split View.
![split_view](https://user-images.githubusercontent.com/323846/34824130-38d940b6-f6f3-11e7-9ca3-e7e68799f091.png)
