### PR TITLE
Make sure back end is up before attempting js tests.

### DIFF
--- a/modules/js-tests/pom.xml
+++ b/modules/js-tests/pom.xml
@@ -140,24 +140,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>run backend</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>java</executable>
-                            <async>true</async>
-                            <arguments>
-                                <argument>-Dbal.composer.home=.</argument>
-                                <argument>-jar</argument>
-                                <argument>
-                                    ${project.build.directory}/lib/composer-server-distribution-${project.version}.jar
-                                </argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>npm test</id>
                         <goals>
                             <goal>exec</goal>
@@ -167,6 +149,8 @@
                             <executable>${npm.executable}</executable>
                             <arguments>
                                 <argument>test</argument>
+                                <argument>--</argument>
+                                <argument>--projectVersion=${project.version}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
+++ b/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
@@ -138,7 +138,6 @@ public class ServerLauncher {
         try {
             server.start();
             String uRL = "http://" + config.getHost() + ":" + config.getPort();
-            logger.info("Composer started successfully at " + uRL);
             PrintStream out = System.out;
             out.println("Composer started successfully at " + uRL);
             BrowserLauncher.startInDefaultBrowser(uRL);

--- a/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
+++ b/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
@@ -139,6 +139,8 @@ public class ServerLauncher {
             server.start();
             String uRL = "http://" + config.getHost() + ":" + config.getPort();
             logger.info("Composer started successfully at " + uRL);
+            PrintStream out = System.out;
+            out.println("Composer started successfully at " + uRL);
             BrowserLauncher.startInDefaultBrowser(uRL);
         } catch (Exception e) {
             logger.error("Error while starting Composer Backend Server.", e);


### PR DESCRIPTION
Previously the back end composer services was started as a async maven
execution. The services may or may not be up when starting js tests.

By starting them inside the test script itself and waiting for services
stdout to print the success message, its guaranteed that the back end is
up when starting js tests.