### PR TITLE
Change log levels of config reading errors

### DIFF
--- a/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
+++ b/modules/server/server-launcher/src/main/java/org/ballerinalang/composer/server/launcher/ServerLauncher.java
@@ -53,7 +53,7 @@ public class ServerLauncher {
             composerLogManagerUtils.updateLogManager();
             logger = LoggerFactory.getLogger(ServerLauncher.class);
         } catch (IOException e) {
-            logger.error("Error occurred while setting logging properties.", e);
+            logger.debug("Error occurred while setting logging properties.", e);
         }
     }
 
@@ -99,7 +99,7 @@ public class ServerLauncher {
                 try {
                     config = mapper.readValue(configFile, ServerConfig.class);
                 } catch (IOException e) {
-                    logger.error("Error while reading config file.", e);
+                    logger.debug("Error while reading config file.", e);
                 }
             }
         }


### PR DESCRIPTION
These errors should not be visible unless user wants to see debug level logs.